### PR TITLE
Update `VariableGroup`s to better handle `set_evidence`

### DIFF
--- a/pgmax/fg/groups.py
+++ b/pgmax/fg/groups.py
@@ -126,8 +126,6 @@ class CompositeVariableGroup(VariableGroup):
 
     Attributes:
         _keys_to_vars: A private, immutable mapping from keys to variables
-        _container_keys: A private tuple containing all valid container keys
-            Can be used to index variable_group_container to get corresponding variable groups
     """
 
     variable_group_container: Union[


### PR DESCRIPTION
This PR makes two updates to `VariableGroup`s:

1. Add a `container_keys` property to `CompositeVariableGroup`s.
2. Implement `get_vars_to_evidence` for different variable groups.

With these changes, we can implement `set_evidence` of a `FactorGraph` by:

Given a `key`, check if it's in `self._cmp_var_group.container_keys`:
- If yes, call `self._cmp_var_group.variable_group_container[key].get_vars_to_evidence(evidence)` to get a dictionary, which can be used to update `self.vars_to_evidence`.
- If no, do `self.vars_to_evidence[self._cmp_var_group[key]] = evidence`.