### PR TITLE
Use `functools.partial` instead of `jax.partial`

### DIFF
--- a/pgmax/bp/bp_utils.py
+++ b/pgmax/bp/bp_utils.py
@@ -1,5 +1,7 @@
 """A module containing helper functions used for belief propagation."""
 
+import functools
+
 import jax
 import jax.numpy as jnp
 
@@ -8,7 +10,7 @@ NEG_INF = (
 )  # A large negative value to use as -inf for numerical stability reasons
 
 
-@jax.partial(jax.jit, static_argnames="max_segment_length")
+@functools.partial(jax.jit, static_argnames="max_segment_length")
 def segment_max_opt(
     data: jnp.ndarray, segments_lengths: jnp.ndarray, max_segment_length: int
 ) -> jnp.ndarray:
@@ -28,7 +30,7 @@ def segment_max_opt(
 
     """
 
-    @jax.partial(jax.vmap, in_axes=(None, 0, 0), out_axes=0)
+    @functools.partial(jax.vmap, in_axes=(None, 0, 0), out_axes=0)
     def get_max(data, start_index, segment_length):
         return jnp.max(
             jnp.where(

--- a/pgmax/bp/infer.py
+++ b/pgmax/bp/infer.py
@@ -1,5 +1,7 @@
 """A module containing the core message-passing functions for belief propagation"""
 
+import functools
+
 import jax
 import jax.numpy as jnp
 
@@ -32,7 +34,7 @@ def pass_var_to_fac_messages(
     return vtof_msgs
 
 
-@jax.partial(jax.jit, static_argnames=("num_val_configs"))
+@functools.partial(jax.jit, static_argnames=("num_val_configs"))
 def pass_fac_to_var_messages(
     vtof_msgs: jnp.ndarray,
     factor_configs_edge_states: jnp.ndarray,
@@ -73,7 +75,7 @@ def pass_fac_to_var_messages(
     return ftov_msgs
 
 
-@jax.partial(jax.jit, static_argnames=("max_msg_size"))
+@functools.partial(jax.jit, static_argnames=("max_msg_size"))
 def normalize_and_clip_msgs(
     msgs: jnp.ndarray,
     edges_num_states: jnp.ndarray,


### PR DESCRIPTION
`jax.partial` has been removed in jax 0.2.21. This PR replaces `jax.partial` with `functools.partial` in preparation for later upgrades to newer jax versions.