### PR TITLE
Changes for blog post

### DIFF
--- a/examples/gmrf.py
+++ b/examples/gmrf.py
@@ -59,30 +59,26 @@ fg = graph.FactorGraph(variables)
 # Add top-down factors
 fg.add_factor_group(
     factory=groups.PairwiseFactorGroup,
-    connected_variable_names=[
-        [(ii, jj), (ii + 1, jj)] for ii in range(M - 1) for jj in range(N)
-    ],
+    variable_names=[[(ii, jj), (ii + 1, jj)] for ii in range(M - 1) for jj in range(N)],
     name="top_down",
 )
 # Add left-right factors
 fg.add_factor_group(
     factory=groups.PairwiseFactorGroup,
-    connected_variable_names=[
-        [(ii, jj), (ii, jj + 1)] for ii in range(M) for jj in range(N - 1)
-    ],
+    variable_names=[[(ii, jj), (ii, jj + 1)] for ii in range(M) for jj in range(N - 1)],
     name="left_right",
 )
 # Add diagonal factors
 fg.add_factor_group(
     factory=groups.PairwiseFactorGroup,
-    connected_variable_names=[
+    variable_names=[
         [(ii, jj), (ii + 1, jj + 1)] for ii in range(M - 1) for jj in range(N - 1)
     ],
     name="diagonal0",
 )
 fg.add_factor_group(
     factory=groups.PairwiseFactorGroup,
-    connected_variable_names=[
+    variable_names=[
         [(ii, jj), (ii - 1, jj + 1)] for ii in range(1, M) for jj in range(N - 1)
     ],
     name="diagonal1",

--- a/examples/gmrf.py
+++ b/examples/gmrf.py
@@ -59,26 +59,30 @@ fg = graph.FactorGraph(variables)
 # Add top-down factors
 fg.add_factor_group(
     factory=groups.PairwiseFactorGroup,
-    variable_names=[[(ii, jj), (ii + 1, jj)] for ii in range(M - 1) for jj in range(N)],
+    connected_variable_names=[
+        [(ii, jj), (ii + 1, jj)] for ii in range(M - 1) for jj in range(N)
+    ],
     name="top_down",
 )
 # Add left-right factors
 fg.add_factor_group(
     factory=groups.PairwiseFactorGroup,
-    variable_names=[[(ii, jj), (ii, jj + 1)] for ii in range(M) for jj in range(N - 1)],
+    connected_variable_names=[
+        [(ii, jj), (ii, jj + 1)] for ii in range(M) for jj in range(N - 1)
+    ],
     name="left_right",
 )
 # Add diagonal factors
 fg.add_factor_group(
     factory=groups.PairwiseFactorGroup,
-    variable_names=[
+    connected_variable_names=[
         [(ii, jj), (ii + 1, jj + 1)] for ii in range(M - 1) for jj in range(N - 1)
     ],
     name="diagonal0",
 )
 fg.add_factor_group(
     factory=groups.PairwiseFactorGroup,
-    variable_names=[
+    connected_variable_names=[
         [(ii, jj), (ii - 1, jj + 1)] for ii in range(1, M) for jj in range(N - 1)
     ],
     name="diagonal1",

--- a/examples/gmrf.py
+++ b/examples/gmrf.py
@@ -51,8 +51,8 @@ prototype_targets = jax.device_put(
 
 # %%
 M, N = target_images.shape[-2:]
-variable_size = np.sum(n_clones)
-variables = groups.NDVariableArray(variable_size=variable_size, shape=(M, N))
+num_states = np.sum(n_clones)
+variables = groups.NDVariableArray(num_states=num_states, shape=(M, N))
 fg = graph.FactorGraph(variables)
 
 # %%
@@ -183,10 +183,10 @@ def update(step, batch_noisy_images, batch_target_images, opt_state):
 # %%
 opt_state = init_fun(
     {
-        "top_down": np.random.randn(variable_size, variable_size),
-        "left_right": np.random.randn(variable_size, variable_size),
-        "diagonal0": np.random.randn(variable_size, variable_size),
-        "diagonal1": np.random.randn(variable_size, variable_size),
+        "top_down": np.random.randn(num_states, num_states),
+        "left_right": np.random.randn(num_states, num_states),
+        "diagonal0": np.random.randn(num_states, num_states),
+        "diagonal1": np.random.randn(num_states, num_states),
     }
 )
 

--- a/examples/gmrf.py
+++ b/examples/gmrf.py
@@ -8,7 +8,7 @@
 #       format_version: '1.3'
 #       jupytext_version: 1.13.2
 #   kernelspec:
-#     display_name: Python 3
+#     display_name: Python 3 (ipykernel)
 #     language: python
 #     name: python3
 # ---
@@ -127,9 +127,9 @@ for plot_idx, idx in tqdm(enumerate(indices), total=n_plots):
     ax[plot_idx, 2].imshow(pred_image)
     ax[plot_idx, 2].axis("off")
     if plot_idx == 0:
-        ax[plot_idx, 0].set_title("Input noisy image", fontsize=40)
-        ax[plot_idx, 1].set_title("Target image", fontsize=40)
-        ax[plot_idx, 2].set_title("GMRF predicted image", fontsize=40)
+        ax[plot_idx, 0].set_title("Input noisy image", fontsize=50)
+        ax[plot_idx, 1].set_title("Ground truth", fontsize=50)
+        ax[plot_idx, 2].set_title("GMRF predicted image", fontsize=50)
 
 fig.tight_layout()
 

--- a/examples/gmrf.py
+++ b/examples/gmrf.py
@@ -59,7 +59,7 @@ fg = graph.FactorGraph(variables)
 # Add top-down factors
 fg.add_factor_group(
     factory=groups.PairwiseFactorGroup,
-    connected_variable_names=[
+    variable_names_for_factors=[
         [(ii, jj), (ii + 1, jj)] for ii in range(M - 1) for jj in range(N)
     ],
     name="top_down",
@@ -67,7 +67,7 @@ fg.add_factor_group(
 # Add left-right factors
 fg.add_factor_group(
     factory=groups.PairwiseFactorGroup,
-    connected_variable_names=[
+    variable_names_for_factors=[
         [(ii, jj), (ii, jj + 1)] for ii in range(M) for jj in range(N - 1)
     ],
     name="left_right",
@@ -75,14 +75,14 @@ fg.add_factor_group(
 # Add diagonal factors
 fg.add_factor_group(
     factory=groups.PairwiseFactorGroup,
-    connected_variable_names=[
+    variable_names_for_factors=[
         [(ii, jj), (ii + 1, jj + 1)] for ii in range(M - 1) for jj in range(N - 1)
     ],
     name="diagonal0",
 )
 fg.add_factor_group(
     factory=groups.PairwiseFactorGroup,
-    connected_variable_names=[
+    variable_names_for_factors=[
         [(ii, jj), (ii - 1, jj + 1)] for ii in range(1, M) for jj in range(N - 1)
     ],
     name="diagonal1",

--- a/examples/ising_model.py
+++ b/examples/ising_model.py
@@ -28,17 +28,17 @@ from pgmax.fg import graph, groups
 # %%
 variables = groups.NDVariableArray(num_states=2, shape=(50, 50))
 fg = graph.FactorGraph(variables=variables)
-variable_names = []
+connected_variable_names = []
 for ii in range(50):
     for jj in range(50):
         kk = (ii + 1) % 50
         ll = (jj + 1) % 50
-        variable_names.append([(ii, jj), (kk, jj)])
-        variable_names.append([(ii, jj), (ii, ll)])
+        connected_variable_names.append([(ii, jj), (kk, jj)])
+        connected_variable_names.append([(ii, jj), (ii, ll)])
 
 fg.add_factor_group(
     factory=groups.PairwiseFactorGroup,
-    variable_names=variable_names,
+    connected_variable_names=connected_variable_names,
     log_potential_matrix=0.8 * np.array([[1.0, -1.0], [-1.0, 1.0]]),
     name="factors",
 )

--- a/examples/ising_model.py
+++ b/examples/ising_model.py
@@ -28,17 +28,17 @@ from pgmax.fg import graph, groups
 # %%
 variables = groups.NDVariableArray(num_states=2, shape=(50, 50))
 fg = graph.FactorGraph(variables=variables)
-connected_variable_names = []
+variable_names = []
 for ii in range(50):
     for jj in range(50):
         kk = (ii + 1) % 50
         ll = (jj + 1) % 50
-        connected_variable_names.append([(ii, jj), (kk, jj)])
-        connected_variable_names.append([(ii, jj), (ii, ll)])
+        variable_names.append([(ii, jj), (kk, jj)])
+        variable_names.append([(ii, jj), (ii, ll)])
 
 fg.add_factor_group(
     factory=groups.PairwiseFactorGroup,
-    connected_variable_names=connected_variable_names,
+    variable_names=variable_names,
     log_potential_matrix=0.8 * np.array([[1.0, -1.0], [-1.0, 1.0]]),
     name="factors",
 )

--- a/examples/ising_model.py
+++ b/examples/ising_model.py
@@ -28,17 +28,17 @@ from pgmax.fg import graph, groups
 # %%
 variables = groups.NDVariableArray(num_states=2, shape=(50, 50))
 fg = graph.FactorGraph(variables=variables)
-connected_variable_names = []
+variable_names_for_factors = []
 for ii in range(50):
     for jj in range(50):
         kk = (ii + 1) % 50
         ll = (jj + 1) % 50
-        connected_variable_names.append([(ii, jj), (kk, jj)])
-        connected_variable_names.append([(ii, jj), (ii, ll)])
+        variable_names_for_factors.append([(ii, jj), (kk, jj)])
+        variable_names_for_factors.append([(ii, jj), (ii, ll)])
 
 fg.add_factor_group(
     factory=groups.PairwiseFactorGroup,
-    connected_variable_names=connected_variable_names,
+    variable_names_for_factors=variable_names_for_factors,
     log_potential_matrix=0.8 * np.array([[1.0, -1.0], [-1.0, 1.0]]),
     name="factors",
 )

--- a/examples/ising_model.py
+++ b/examples/ising_model.py
@@ -26,7 +26,7 @@ from pgmax.fg import graph, groups
 # ### Construct variable grid, initialize factor graph, and add factors
 
 # %%
-variables = groups.NDVariableArray(variable_size=2, shape=(50, 50))
+variables = groups.NDVariableArray(num_states=2, shape=(50, 50))
 fg = graph.FactorGraph(variables=variables)
 connected_variable_names = []
 for ii in range(50):

--- a/examples/rbm.py
+++ b/examples/rbm.py
@@ -35,8 +35,8 @@ nh = bh.shape[0]
 
 # %%
 # Build factor graph
-visible_variables = groups.NDVariableArray(variable_size=2, shape=(nv,))
-hidden_variables = groups.NDVariableArray(variable_size=2, shape=(nh,))
+hidden_variables = groups.NDVariableArray(num_states=2, shape=(nh,))
+visible_variables = groups.NDVariableArray(num_states=2, shape=(nv,))
 fg = graph.FactorGraph(
     variables=dict(visible=visible_variables, hidden=hidden_variables),
 )
@@ -57,7 +57,7 @@ for ii in tqdm(range(nh)):
         )
 
 # %%
-run_bp, _, get_beliefs = graph.BP(fg.bp_state, 200)
+run_bp, _, get_beliefs = graph.BP(fg.bp_state, 100)
 
 # %%
 # Run inference and decode using vmap

--- a/examples/rbm.py
+++ b/examples/rbm.py
@@ -13,8 +13,14 @@
 #     name: python3
 # ---
 
+# %% [markdown]
+# [Restricted Boltzmann Machine (RBM)](https://en.wikipedia.org/wiki/Restricted_Boltzmann_machine) is a well-known and widely used PGM for learning probabilistic distributions over binary data. we demonstrate how we can easily implement [perturb-and-max-product (PMP)](https://proceedings.neurips.cc/paper/2021/hash/07b1c04a30f798b5506c1ec5acfb9031-Abstract.html) sampling from an RBM trained on MNIST digits using PGMax. PMP is a recently proposed method for approximately sampling from a PGM by computing the maximum-a-posteriori (MAP) configuration (using max-product LBP) of a perturbed version of the model.
+#
+# We start by making some necessary imports.
+
 # %%
 # %matplotlib inline
+import functools
 import itertools
 
 import jax
@@ -24,12 +30,20 @@ from tqdm.notebook import tqdm
 
 from pgmax.fg import graph, groups
 
+# %% [markdown]
+# The [`pgmax.fg.graph`](https://pgmax.readthedocs.io/en/latest/_autosummary/pgmax.fg.graph.html#module-pgmax.fg.graph) module contains core classes for specifying factor graphs and implementing LBP, while the [`pgmax.fg.groups`](https://pgmax.readthedocs.io/en/latest/_autosummary/pgmax.fg.graph.html#module-pgmax.fg.graph) module contains classes for specifying groups of variables/factors.
+#
+# We next load the RBM trained in Sec. 5.5 of the [PMP paper](https://proceedings.neurips.cc/paper/2021/hash/07b1c04a30f798b5506c1ec5acfb9031-Abstract.html) on MNIST digits.
+
 # %%
 # Load parameters
 params = np.load("example_data/rbm_mnist.npz")
 bv = params["bv"]
 bh = params["bh"]
 W = params["W"]
+
+# %% [markdown]
+# We can then initialize the factor graph for the RBM with
 
 # %%
 # Initialize factor graph
@@ -38,6 +52,11 @@ visible_variables = groups.NDVariableArray(num_states=2, shape=bv.shape)
 fg = graph.FactorGraph(
     variables=dict(hidden=hidden_variables, visible=visible_variables),
 )
+
+# %% [markdown]
+# [`NDVariableArray`](https://pgmax.readthedocs.io/en/latest/_autosummary/pgmax.fg.groups.NDVariableArray.html#pgmax.fg.groups.NDVariableArray) is a convenient class for specifying a group of variables living on a multidimensional grid with the same number of states, and shares some similarities with [`numpy.ndarray`](https://numpy.org/doc/stable/reference/generated/numpy.ndarray.html). The [`FactorGraph`](https://pgmax.readthedocs.io/en/latest/_autosummary/pgmax.fg.graph.FactorGraph.html#pgmax.fg.graph.FactorGraph) `fg` is initialized with a set of variables, which can be either a single [`VariableGroup`](https://pgmax.readthedocs.io/en/latest/_autosummary/pgmax.fg.groups.VariableGroup.html#pgmax.fg.groups.VariableGroup) (e.g. an [`NDVariableArray`](https://pgmax.readthedocs.io/en/latest/_autosummary/pgmax.fg.groups.NDVariableArray.html#pgmax.fg.groups.NDVariableArray)), or a list/dictionary of [`VariableGroup`](https://pgmax.readthedocs.io/en/latest/_autosummary/pgmax.fg.groups.VariableGroup.html#pgmax.fg.groups.VariableGroup)s. Once initialized, the set of variables in `fg` is fixed and cannot be changed.
+#
+# After initialization, `fg` does not have any factors. PGMax supports imperatively adding factors to a [`FactorGraph`](https://pgmax.readthedocs.io/en/latest/_autosummary/pgmax.fg.graph.FactorGraph.html#pgmax.fg.graph.FactorGraph). We can add the unary and pairwise factors one at a time to `fg` by
 
 # %%
 # Add unary factors
@@ -56,7 +75,7 @@ for jj in range(bv.shape[0]):
     )
 
 
-# Add binary factors
+# Add pairwise factors
 factor_configs = np.array(list(itertools.product(np.arange(2), repeat=2)))
 for ii in tqdm(range(bh.shape[0])):
     for jj in range(bv.shape[0]):
@@ -66,7 +85,11 @@ for ii in tqdm(range(bh.shape[0])):
             log_potentials=np.array([0, 0, 0, W[ii, jj]]),
         )
 
-# %%
+# %% [markdown]
+# [`fg.add_factor`](https://pgmax.readthedocs.io/en/latest/_autosummary/pgmax.fg.graph.FactorGraph.html#pgmax.fg.graph.FactorGraph.add_factor) takes 3 arguments, `variable_names`, `factor_configs` and `log_potentials`, and is a literal translation of the factor definitions shown in Table [tab:unary] and Table [tab:binary]. `variable_names` is a list containing the name of the involved variables. In this example, since we construct `fg` with variables `dict(hidden=hidden_variables, visible=visible_variables)`, where `hidden_variables` and `visible_variables` are [`NDVariableArray`](https://pgmax.readthedocs.io/en/latest/_autosummary/pgmax.fg.groups.NDVariableArray.html#pgmax.fg.groups.NDVariableArray)s, we can refer to the `ii`th hidden variable as `("hidden", ii)` and the `jj`th visible variable as `("visible", jj)`. In general, PGMax implements an intuitive scheme for automatically assigning names to the variables in a [`FactorGraph`](https://pgmax.readthedocs.io/en/latest/_autosummary/pgmax.fg.graph.FactorGraph.html#pgmax.fg.graph.FactorGraph).
+#
+# PGMax also implements convenient [`FactorGroup`](https://pgmax.readthedocs.io/en/latest/_autosummary/pgmax.fg.groups.FactorGroup.html#pgmax.fg.groups.FactorGroup)s for adding groups of similar factors. An alternative way of adding the above factors using [`FactorGroup`](https://pgmax.readthedocs.io/en/latest/_autosummary/pgmax.fg.groups.FactorGroup.html#pgmax.fg.groups.FactorGroup)s is by calling [`fg.add_factor_group`](https://pgmax.readthedocs.io/en/latest/_autosummary/pgmax.fg.graph.FactorGraph.html#pgmax.fg.graph.FactorGraph.add_factor_group)
+# ~~~python
 # # Add unary factors
 # fg.add_factor_group(
 #     factory=groups.EnumerationFactorGroup,
@@ -81,7 +104,7 @@ for ii in tqdm(range(bh.shape[0])):
 #     log_potentials=np.stack([np.zeros_like(bv), bv], axis=1),
 # )
 #
-# # Add binary factors
+# # Add pairwise factors
 # log_potential_matrix = np.zeros(W.shape + (2, 2)).reshape((-1, 2, 2))
 # log_potential_matrix[:, 1, 1] = W.ravel()
 # fg.add_factor_group(
@@ -93,42 +116,95 @@ for ii in tqdm(range(bh.shape[0])):
 #     ],
 #     log_potential_matrix=log_potential_matrix,
 # )
+# ~~~
+#
+# This makes use of [`EnumerationFactorGroup`](https://pgmax.readthedocs.io/en/latest/_autosummary/pgmax.fg.groups.EnumerationFactorGroup.html#pgmax.fg.groups.EnumerationFactorGroup) and [`PairwiseFactorGroup`](https://pgmax.readthedocs.io/en/latest/_autosummary/pgmax.fg.groups.PairwiseFactorGroup.html#pgmax.fg.groups.PairwiseFactorGroup), two [`FactorGroup`](https://pgmax.readthedocs.io/en/latest/_autosummary/pgmax.fg.groups.FactorGroup.html#pgmax.fg.groups.FactorGroup)s implemented in the [`pgmax.fg.groups`](https://pgmax.readthedocs.io/en/latest/_autosummary/pgmax.fg.graph.html#module-pgmax.fg.graph) module.
+#
+# Once we have added the factors, we can run max-product LBP and get MAP decoding by
+# ~~~python
+# run_bp, get_bp_state, get_beliefs = graph.BP(fg.bp_state, num_iters=100, temperature=0.0)
+# bp_arrays = run_bp(damping=0.5)
+# beliefs = get_beliefs(bp_arrays)
+# map_states = graph.decode_map_states(beliefs)
+# ~~~
+# and run sum-product LBP and get estimated marginals by
+# ~~~python
+# run_bp, get_bp_state, get_beliefs = graph.BP(fg.bp_state, num_iters=100, temperature=1.0)
+# bp_arrays = run_bp(damping=0.5)
+# beliefs = get_beliefs(bp_arrays)
+# marginals = graph.get_marginals(beliefs)
+# ~~~
+# More generally, PGMax implements LBP with temperature, with `temperature=0.0` and `temperature=1.0` corresponding to the commonly used max/sum-product LBP respectively.
+#
+# Now we are ready to demonstrate PMP sampling from RBM. PMP perturbs the model with [Gumbel](https://numpy.org/doc/stable/reference/random/generated/numpy.random.gumbel.html) unary potentials, and draws a sample from the RBM as the MAP decoding from running max-product LBP on the perturbed model
 
 # %%
-run_bp, _, get_beliefs = graph.BP(fg.bp_state, 100)
+run_bp, get_bp_state, get_beliefs = graph.BP(
+    fg.bp_state, num_iters=100, temperature=0.0
+)
 
 # %%
-# Run inference and decode using vmap
-n_samples = 16
-bp_arrays = jax.vmap(run_bp, in_axes=0, out_axes=0)(
+bp_arrays = run_bp(
     evidence_updates={
-        "hidden": np.stack(
-            [
-                np.zeros((n_samples,) + bh.shape),
-                np.random.logistic(size=(n_samples,) + bh.shape),
-            ],
-            axis=-1,
-        ),
-        "visible": np.stack(
-            [
-                np.zeros((n_samples,) + bv.shape),
-                np.random.logistic(size=(n_samples,) + bv.shape),
-            ],
-            axis=-1,
-        ),
-    }
+        "hidden": np.random.gumbel(size=(bh.shape[0], 2)),
+        "visible": np.random.gumbel(size=(bv.shape[0], 2)),
+    },
+    damping=0.5,
 )
-map_states = graph.decode_map_states(
-    jax.vmap(get_beliefs, in_axes=0, out_axes=0)(bp_arrays)
-)
+beliefs = get_beliefs(bp_arrays)
+map_states = graph.decode_map_states(beliefs)
+
+# %% [markdown]
+# Here we use the `evidence_updates` argument of `run_bp` to perturb the model with Gumbel unary potentials. In general, `evidence_updates` can be used to incorporate evidence in the form of externally applied unary potentials in PGM inference.
+#
+# Visualizing the MAP decoding (Figure [fig:rbm_single_digit]), we see that we have sampled an MNIST digit!
 
 # %%
-# Visualize decodings
-fig, ax = plt.subplots(4, 4, figsize=(10, 10))
-for ii in range(16):
-    ax[np.unravel_index(ii, (4, 4))].imshow(
-        map_states["visible"][ii].copy().reshape((28, 28))
+fig, ax = plt.subplots(1, 1, figsize=(10, 10))
+ax.imshow(map_states["visible"].copy().reshape((28, 28)), cmap="gray")
+ax.axis("off")
+
+# %% [markdown]
+# PGMax adopts a functional interface for implementing LBP: running LBP in PGMax starts with
+# ~~~python
+# run_bp, get_bp_state, get_beliefs = graph.BP(fg.bp_state, num_iters=NUM_ITERS, temperature=T)
+# ~~~
+# where `run_bp` and `get_beliefs` are pure functions with no side-effects. This design choice means that we can easily apply JAX transformations like `jit`/`vmap`/`grad`, etc., to these functions, and additionally allows PGMax to seamlessly interact with other packages in the rapidly growing JAX ecosystem (see [here](https://deepmind.com/blog/article/using-jax-to-accelerate-our-research) and [here](https://github.com/n2cholas/awesome-jax)). In what follows we demonstrate an example on applying `jax.vmap`, a convenient transformation for automatically vectorizing functions.
+#
+# Since we implement `run_bp`/`get_beliefs` as a pure function, we can apply `jax.vmap` to `run_bp`/`get_beliefs` to process a batch of samples/models in parallel. As an example, consider the PGMax implementation of PMP sampling from the RBM trained on MNIST images in Section [Tutorial: implementing LBP inference for RBMs with PGMax]. Instead of drawing one sample at a time
+# ~~~python
+# bp_arrays = run_bp(
+#     evidence_updates={
+#         "hidden": np.random.gumbel(size=(bh.shape[0], 2)),
+#         "visible": np.random.gumbel(size=(bv.shape[0], 2)),
+#     },
+#     damping=0.5,
+# )
+# beliefs = get_beliefs(bp_arrays)
+# map_states = graph.decode_map_states(beliefs)
+# ~~~
+# we can draw a batch of samples in parallel by transforming `run_bp`/`get_beliefs` with `jax.vmap`
+
+# %%
+n_samples = 10
+bp_arrays = jax.vmap(functools.partial(run_bp, damping=0.5), in_axes=0, out_axes=0)(
+    evidence_updates={
+        "hidden": np.random.gumbel(size=(n_samples, bh.shape[0], 2)),
+        "visible": np.random.gumbel(size=(n_samples, bv.shape[0], 2)),
+    },
+)
+beliefs = jax.vmap(get_beliefs, in_axes=0, out_axes=0)(bp_arrays)
+map_states = graph.decode_map_states(beliefs)
+
+# %% [markdown]
+# Visualizing the MAP decodings (Figure [fig:rbm_multiple_digits]), we see that we have sampled 10 MNIST digits in parallel!
+
+# %%
+fig, ax = plt.subplots(2, 5, figsize=(20, 8))
+for ii in range(10):
+    ax[np.unravel_index(ii, (2, 5))].imshow(
+        map_states["visible"][ii].copy().reshape((28, 28)), cmap="gray"
     )
-    ax[np.unravel_index(ii, (4, 4))].axis("off")
+    ax[np.unravel_index(ii, (2, 5))].axis("off")
 
 fig.tight_layout()

--- a/examples/rcn.py
+++ b/examples/rcn.py
@@ -8,7 +8,7 @@
 #       format_version: '1.3'
 #       jupytext_version: 1.13.2
 #   kernelspec:
-#     display_name: Python 3
+#     display_name: Python 3 (ipykernel)
 #     language: python
 #     name: python3
 # ---
@@ -214,7 +214,7 @@ variables_all_models = {}
 for idx in range(frcs.shape[0]):
     frc = frcs[idx]
     variables_all_models[idx] = groups.NDVariableArray(
-        variable_size=M, shape=(frc.shape[0],)
+        num_states=M, shape=(frc.shape[0],)
     )
 
 end = time.time()
@@ -447,5 +447,3 @@ for test_idx in range(20):
     ax[idx].axis("off")
 
 fig.tight_layout()
-
-# %%

--- a/examples/rcn.py
+++ b/examples/rcn.py
@@ -157,7 +157,8 @@ fig, ax = plt.subplots(1, 2, figsize=(20, 10))
 
 frc, edge, train_img = frcs[img_idx], edges[img_idx], train_set[img_idx]
 ax[0].imshow(train_img[pad : 200 - pad, pad : 200 - pad], cmap="gray")
-ax[0].set_title("Sample training image", fontsize=40)
+ax[0].axis("off")
+ax[0].set_title("Example training image", fontsize=40)
 
 for e in edge:
     i1, i2, w = e  # The vertices for this edge along with the perturn radius.
@@ -173,7 +174,7 @@ for e in edge:
 
 ax[1].axis("off")
 ax[1].imshow(model_img[pad : 200 - pad, pad : 200 - pad], cmap="gray")
-ax[1].set_title("Corresponding learned rcn model", fontsize=40)
+ax[1].set_title("Corresponding RCN template", fontsize=40)
 
 fig.tight_layout()
 
@@ -229,7 +230,7 @@ print(f"Creating variables took {end-start:.3f} seconds.")
 
 # %%
 def valid_configs(r: int, hps: int, vps: int) -> np.ndarray:
-    """Returns the valid configurations for the potential matrix given the perturb radius.
+    """Returns the valid configurations for a factor given the perturb radius.
 
     Args:
         r: Peturb radius
@@ -237,12 +238,15 @@ def valid_configs(r: int, hps: int, vps: int) -> np.ndarray:
         vps: The vertical pool size.
 
     Returns:
-        A configuration matrix (shape n X 2) where n is the number of valid configurations.
+        An array of shape (num_valid_configs, 2) containing all valid configurations
     """
-
     configs = []
     for i, (r1, c1) in enumerate(
-        np.array(np.unravel_index(np.arange(M), (2 * hps + 1, 2 * vps + 1))).T
+        np.array(
+            np.unravel_index(
+                np.arange((2 * hps + 1) * (2 * vps + 1)), (2 * hps + 1, 2 * vps + 1)
+            )
+        ).T
     ):
         r2_min = max(r1 - r, 0)
         r2_max = min(r1 + r, 2 * hps)

--- a/pgmax/fg/graph.py
+++ b/pgmax/fg/graph.py
@@ -737,7 +737,7 @@ class Evidence:
             name: The name of a variable group or a single variable.
                 If name is the name of a variable group, updates are derived by using the variable group to
                 flatten the data.
-                If name is the name of a variable, data should be of an array shape (variable_size,)
+                If name is the name of a variable, data should be of an array shape (num_states,)
                 If name is None, updates are derived by using self.fg_state.variable_group to flatten the data.
             data: Array containing the evidence updates.
         """

--- a/pgmax/fg/graph.py
+++ b/pgmax/fg/graph.py
@@ -118,7 +118,7 @@ class FactorGraph:
         """
         factor_group = groups.EnumerationFactorGroup(
             self._variable_group,
-            connected_variable_names=[variable_names],
+            variable_names_for_factors=[variable_names],
             factor_configs=factor_configs,
             log_potentials=log_potentials,
         )

--- a/pgmax/fg/graph.py
+++ b/pgmax/fg/graph.py
@@ -118,7 +118,7 @@ class FactorGraph:
         """
         factor_group = groups.EnumerationFactorGroup(
             self._variable_group,
-            connected_variable_names=[variable_names],
+            variable_names=[variable_names],
             factor_configs=factor_configs,
             log_potentials=log_potentials,
         )

--- a/pgmax/fg/graph.py
+++ b/pgmax/fg/graph.py
@@ -118,7 +118,7 @@ class FactorGraph:
         """
         factor_group = groups.EnumerationFactorGroup(
             self._variable_group,
-            variable_names=[variable_names],
+            connected_variable_names=[variable_names],
             factor_configs=factor_configs,
             log_potentials=log_potentials,
         )

--- a/pgmax/fg/groups.py
+++ b/pgmax/fg/groups.py
@@ -900,8 +900,8 @@ class PairwiseFactorGroup(FactorGroup):
 
         factor_configs = (
             np.mgrid[
-                : log_potential_matrix.shape[0],
-                : log_potential_matrix.shape[1],
+                : log_potential_matrix.shape[-1],
+                : log_potential_matrix.shape[-2],
             ]
             .transpose((1, 2, 0))
             .reshape((-1, 2))

--- a/pgmax/fg/groups.py
+++ b/pgmax/fg/groups.py
@@ -900,8 +900,8 @@ class PairwiseFactorGroup(FactorGroup):
 
         factor_configs = (
             np.mgrid[
-                : log_potential_matrix.shape[-1],
                 : log_potential_matrix.shape[-2],
+                : log_potential_matrix.shape[-1],
             ]
             .transpose((1, 2, 0))
             .reshape((-1, 2))

--- a/pgmax/fg/groups.py
+++ b/pgmax/fg/groups.py
@@ -560,7 +560,7 @@ class FactorGroup:
         _variables_to_factors: maps set of connected variables to the corresponding factors
 
     Raises:
-        ValueError: if connected_variable_names is an empty list
+        ValueError: if variable_names is an empty list
     """
 
     variable_group: Union[CompositeVariableGroup, VariableGroup]
@@ -671,7 +671,7 @@ class EnumerationFactorGroup(FactorGroup):
     uniform 0 unless the inheriting class includes a log_potentials argument.
 
     Args:
-        connected_variable_names: A list of list of variable names, where each innermost element is the
+        variable_names: A list of list of variable names, where each innermost element is the
             name of a variable in variable_group. Each list within the outer list is taken to contain
             the names of the variables connected to a factor.
         factor_configs: Array of shape (num_val_configs, num_variables)
@@ -682,7 +682,7 @@ class EnumerationFactorGroup(FactorGroup):
             initialized.
     """
 
-    connected_variable_names: Sequence[List]
+    variable_names: Sequence[List]
     factor_configs: np.ndarray
     log_potentials: Optional[np.ndarray] = None
 
@@ -697,7 +697,7 @@ class EnumerationFactorGroup(FactorGroup):
         Raises:
             ValueError: if the specified log_potentials is not of the right shape
         """
-        num_factors = len(self.connected_variable_names)
+        num_factors = len(self.variable_names)
         num_val_configs = self.factor_configs.shape[0]
         if self.log_potentials is None:
             log_potentials = np.zeros((num_factors, num_val_configs), dtype=float)
@@ -720,14 +720,14 @@ class EnumerationFactorGroup(FactorGroup):
         variables_to_factors = collections.OrderedDict(
             [
                 (
-                    frozenset(self.connected_variable_names[ii]),
+                    frozenset(self.variable_names[ii]),
                     nodes.EnumerationFactor(
-                        tuple(self.variable_group[self.connected_variable_names[ii]]),
+                        tuple(self.variable_group[self.variable_names[ii]]),
                         self.factor_configs,
                         log_potentials[ii],
                     ),
                 )
-                for ii in range(len(self.connected_variable_names))
+                for ii in range(len(self.variable_names))
             ]
         )
         return variables_to_factors
@@ -821,15 +821,15 @@ class PairwiseFactorGroup(FactorGroup):
     one CompositeVariableGroup.
 
     Args:
-        connected_variable_names: A list of list of tuples, where each innermost tuple contains a
+        variable_names: A list of list of tuples, where each innermost tuple contains a
             name into variable_group. Each list within the outer list is taken to contain the names of variables
             neighboring a particular factor to be added.
         log_potential_matrix: array of shape (var1.num_states, var2.num_states),
             where var1 and var2 are the 2 VariableGroups (that may refer to the same
-            VariableGroup) whose names are present in each sub-list from self.connected_variable_names.
+            VariableGroup) whose names are present in each sub-list from self.variable_names.
     """
 
-    connected_variable_names: Sequence[List]
+    variable_names: Sequence[List]
     log_potential_matrix: Optional[np.ndarray] = None
 
     def _get_variables_to_factors(
@@ -851,8 +851,8 @@ class PairwiseFactorGroup(FactorGroup):
         if self.log_potential_matrix is None:
             log_potential_matrix = np.zeros(
                 (
-                    self.variable_group[self.connected_variable_names[0][0]].num_states,
-                    self.variable_group[self.connected_variable_names[0][1]].num_states,
+                    self.variable_group[self.variable_names[0][0]].num_states,
+                    self.variable_group[self.variable_names[0][1]].num_states,
                 )
             )
         else:
@@ -866,14 +866,14 @@ class PairwiseFactorGroup(FactorGroup):
             )
 
         if log_potential_matrix.ndim == 3 and log_potential_matrix.shape[0] != len(
-            self.connected_variable_names
+            self.variable_names
         ):
             raise ValueError(
-                f"Expected log_potential_matrix for {len(self.connected_variable_names)} factors. "
+                f"Expected log_potential_matrix for {len(self.variable_names)} factors. "
                 f"Got log_potential_matrix for {log_potential_matrix.shape[0]} factors."
             )
 
-        for fac_list in self.connected_variable_names:
+        for fac_list in self.variable_names:
             if len(fac_list) != 2:
                 raise ValueError(
                     "All pairwise factors should connect to exactly 2 variables. Got a factor connecting to"
@@ -905,21 +905,21 @@ class PairwiseFactorGroup(FactorGroup):
         object.__setattr__(self, "log_potential_matrix", log_potential_matrix)
         log_potential_matrix = np.broadcast_to(
             log_potential_matrix,
-            (len(self.connected_variable_names),) + log_potential_matrix.shape[-2:],
+            (len(self.variable_names),) + log_potential_matrix.shape[-2:],
         )
         variables_to_factors = collections.OrderedDict(
             [
                 (
-                    frozenset(self.connected_variable_names[ii]),
+                    frozenset(self.variable_names[ii]),
                     nodes.EnumerationFactor(
-                        tuple(self.variable_group[self.connected_variable_names[ii]]),
+                        tuple(self.variable_group[self.variable_names[ii]]),
                         factor_configs,
                         log_potential_matrix[
                             ii, factor_configs[:, 0], factor_configs[:, 1]
                         ],
                     ),
                 )
-                for ii in range(len(self.connected_variable_names))
+                for ii in range(len(self.variable_names))
             ]
         )
         return variables_to_factors

--- a/pgmax/fg/groups.py
+++ b/pgmax/fg/groups.py
@@ -560,7 +560,7 @@ class FactorGroup:
         _variables_to_factors: maps set of connected variables to the corresponding factors
 
     Raises:
-        ValueError: if connected_variable_names is an empty list
+        ValueError: if variable_names_for_factors is an empty list
     """
 
     variable_group: Union[CompositeVariableGroup, VariableGroup]
@@ -671,7 +671,7 @@ class EnumerationFactorGroup(FactorGroup):
     uniform 0 unless the inheriting class includes a log_potentials argument.
 
     Args:
-        connected_variable_names: A list of list of variable names, where each innermost element is the
+        variable_names_for_factors: A list of list of variable names, where each innermost element is the
             name of a variable in variable_group. Each list within the outer list is taken to contain
             the names of the variables connected to a factor.
         factor_configs: Array of shape (num_val_configs, num_variables)
@@ -682,7 +682,7 @@ class EnumerationFactorGroup(FactorGroup):
             initialized.
     """
 
-    connected_variable_names: Sequence[List]
+    variable_names_for_factors: Sequence[List]
     factor_configs: np.ndarray
     log_potentials: Optional[np.ndarray] = None
 
@@ -697,7 +697,7 @@ class EnumerationFactorGroup(FactorGroup):
         Raises:
             ValueError: if the specified log_potentials is not of the right shape
         """
-        num_factors = len(self.connected_variable_names)
+        num_factors = len(self.variable_names_for_factors)
         num_val_configs = self.factor_configs.shape[0]
         if self.log_potentials is None:
             log_potentials = np.zeros((num_factors, num_val_configs), dtype=float)
@@ -720,14 +720,14 @@ class EnumerationFactorGroup(FactorGroup):
         variables_to_factors = collections.OrderedDict(
             [
                 (
-                    frozenset(self.connected_variable_names[ii]),
+                    frozenset(self.variable_names_for_factors[ii]),
                     nodes.EnumerationFactor(
-                        tuple(self.variable_group[self.connected_variable_names[ii]]),
+                        tuple(self.variable_group[self.variable_names_for_factors[ii]]),
                         self.factor_configs,
                         log_potentials[ii],
                     ),
                 )
-                for ii in range(len(self.connected_variable_names))
+                for ii in range(len(self.variable_names_for_factors))
             ]
         )
         return variables_to_factors
@@ -821,15 +821,15 @@ class PairwiseFactorGroup(FactorGroup):
     one CompositeVariableGroup.
 
     Args:
-        connected_variable_names: A list of list of tuples, where each innermost tuple contains a
+        variable_names_for_factors: A list of list of tuples, where each innermost tuple contains a
             name into variable_group. Each list within the outer list is taken to contain the names of variables
             neighboring a particular factor to be added.
         log_potential_matrix: array of shape (var1.num_states, var2.num_states),
             where var1 and var2 are the 2 VariableGroups (that may refer to the same
-            VariableGroup) whose names are present in each sub-list from self.connected_variable_names.
+            VariableGroup) whose names are present in each sub-list from self.variable_names_for_factors.
     """
 
-    connected_variable_names: Sequence[List]
+    variable_names_for_factors: Sequence[List]
     log_potential_matrix: Optional[np.ndarray] = None
 
     def _get_variables_to_factors(
@@ -851,8 +851,12 @@ class PairwiseFactorGroup(FactorGroup):
         if self.log_potential_matrix is None:
             log_potential_matrix = np.zeros(
                 (
-                    self.variable_group[self.connected_variable_names[0][0]].num_states,
-                    self.variable_group[self.connected_variable_names[0][1]].num_states,
+                    self.variable_group[
+                        self.variable_names_for_factors[0][0]
+                    ].num_states,
+                    self.variable_group[
+                        self.variable_names_for_factors[0][1]
+                    ].num_states,
                 )
             )
         else:
@@ -866,14 +870,14 @@ class PairwiseFactorGroup(FactorGroup):
             )
 
         if log_potential_matrix.ndim == 3 and log_potential_matrix.shape[0] != len(
-            self.connected_variable_names
+            self.variable_names_for_factors
         ):
             raise ValueError(
-                f"Expected log_potential_matrix for {len(self.connected_variable_names)} factors. "
+                f"Expected log_potential_matrix for {len(self.variable_names_for_factors)} factors. "
                 f"Got log_potential_matrix for {log_potential_matrix.shape[0]} factors."
             )
 
-        for fac_list in self.connected_variable_names:
+        for fac_list in self.variable_names_for_factors:
             if len(fac_list) != 2:
                 raise ValueError(
                     "All pairwise factors should connect to exactly 2 variables. Got a factor connecting to"
@@ -905,21 +909,21 @@ class PairwiseFactorGroup(FactorGroup):
         object.__setattr__(self, "log_potential_matrix", log_potential_matrix)
         log_potential_matrix = np.broadcast_to(
             log_potential_matrix,
-            (len(self.connected_variable_names),) + log_potential_matrix.shape[-2:],
+            (len(self.variable_names_for_factors),) + log_potential_matrix.shape[-2:],
         )
         variables_to_factors = collections.OrderedDict(
             [
                 (
-                    frozenset(self.connected_variable_names[ii]),
+                    frozenset(self.variable_names_for_factors[ii]),
                     nodes.EnumerationFactor(
-                        tuple(self.variable_group[self.connected_variable_names[ii]]),
+                        tuple(self.variable_group[self.variable_names_for_factors[ii]]),
                         factor_configs,
                         log_potential_matrix[
                             ii, factor_configs[:, 0], factor_configs[:, 1]
                         ],
                     ),
                 )
-                for ii in range(len(self.connected_variable_names))
+                for ii in range(len(self.variable_names_for_factors))
             ]
         )
         return variables_to_factors

--- a/tests/fg/test_groups.py
+++ b/tests/fg/test_groups.py
@@ -158,7 +158,7 @@ def test_enumeration_factor_group():
     ):
         enumeration_factor_group = groups.EnumerationFactorGroup(
             variable_group=variable_group,
-            variable_names=[
+            connected_variable_names=[
                 [(0, 0), (0, 1), (1, 1)],
                 [(0, 1), (1, 0), (1, 1)],
             ],
@@ -168,7 +168,7 @@ def test_enumeration_factor_group():
 
     enumeration_factor_group = groups.EnumerationFactorGroup(
         variable_group=variable_group,
-        variable_names=[[(0, 0), (0, 1), (1, 1)], [(0, 1), (1, 0), (1, 1)]],
+        connected_variable_names=[[(0, 0), (0, 1), (1, 1)], [(0, 1), (1, 0), (1, 1)]],
         factor_configs=np.zeros((1, 3), dtype=int),
     )
     name = [(0, 0), (1, 1)]

--- a/tests/fg/test_groups.py
+++ b/tests/fg/test_groups.py
@@ -158,7 +158,7 @@ def test_enumeration_factor_group():
     ):
         enumeration_factor_group = groups.EnumerationFactorGroup(
             variable_group=variable_group,
-            connected_variable_names=[
+            variable_names=[
                 [(0, 0), (0, 1), (1, 1)],
                 [(0, 1), (1, 0), (1, 1)],
             ],
@@ -168,7 +168,7 @@ def test_enumeration_factor_group():
 
     enumeration_factor_group = groups.EnumerationFactorGroup(
         variable_group=variable_group,
-        connected_variable_names=[[(0, 0), (0, 1), (1, 1)], [(0, 1), (1, 0), (1, 1)]],
+        variable_names=[[(0, 0), (0, 1), (1, 1)], [(0, 1), (1, 0), (1, 1)]],
         factor_configs=np.zeros((1, 3), dtype=int),
     )
     name = [(0, 0), (1, 1)]

--- a/tests/fg/test_groups.py
+++ b/tests/fg/test_groups.py
@@ -158,7 +158,7 @@ def test_enumeration_factor_group():
     ):
         enumeration_factor_group = groups.EnumerationFactorGroup(
             variable_group=variable_group,
-            connected_variable_names=[
+            variable_names_for_factors=[
                 [(0, 0), (0, 1), (1, 1)],
                 [(0, 1), (1, 0), (1, 1)],
             ],
@@ -168,7 +168,7 @@ def test_enumeration_factor_group():
 
     enumeration_factor_group = groups.EnumerationFactorGroup(
         variable_group=variable_group,
-        connected_variable_names=[[(0, 0), (0, 1), (1, 1)], [(0, 1), (1, 0), (1, 1)]],
+        variable_names_for_factors=[[(0, 0), (0, 1), (1, 1)], [(0, 1), (1, 0), (1, 1)]],
         factor_configs=np.zeros((1, 3), dtype=int),
     )
     name = [(0, 0), (1, 1)]

--- a/tests/test_pgmax.py
+++ b/tests/test_pgmax.py
@@ -350,12 +350,14 @@ def test_e2e_sanity_check():
     # Add the suppression factors to the graph via kwargs
     fg.add_factor_group(
         factory=groups.EnumerationFactorGroup,
-        variable_names={idx: names for idx, names in enumerate(vert_suppression_names)},
+        connected_variable_names={
+            idx: names for idx, names in enumerate(vert_suppression_names)
+        },
         factor_configs=valid_configs_supp,
     )
     fg.add_factor_group(
         factory=groups.EnumerationFactorGroup,
-        variable_names=horz_suppression_names,
+        connected_variable_names=horz_suppression_names,
         factor_configs=valid_configs_supp,
         log_potentials=np.zeros(valid_configs_supp.shape[0], dtype=float),
     )
@@ -408,7 +410,9 @@ def test_e2e_heretic():
         for k_col in range(3):
             fg.add_factor_group(
                 factory=groups.PairwiseFactorGroup,
-                variable_names=binary_connected_variables(28, 28, k_row, k_col),
+                connected_variable_names=binary_connected_variables(
+                    28, 28, k_row, k_col
+                ),
                 log_potential_matrix=W_pot[:, :, k_row, k_col],
                 name=(k_row, k_col),
             )

--- a/tests/test_pgmax.py
+++ b/tests/test_pgmax.py
@@ -350,14 +350,12 @@ def test_e2e_sanity_check():
     # Add the suppression factors to the graph via kwargs
     fg.add_factor_group(
         factory=groups.EnumerationFactorGroup,
-        connected_variable_names={
-            idx: names for idx, names in enumerate(vert_suppression_names)
-        },
+        variable_names={idx: names for idx, names in enumerate(vert_suppression_names)},
         factor_configs=valid_configs_supp,
     )
     fg.add_factor_group(
         factory=groups.EnumerationFactorGroup,
-        connected_variable_names=horz_suppression_names,
+        variable_names=horz_suppression_names,
         factor_configs=valid_configs_supp,
         log_potentials=np.zeros(valid_configs_supp.shape[0], dtype=float),
     )
@@ -410,9 +408,7 @@ def test_e2e_heretic():
         for k_col in range(3):
             fg.add_factor_group(
                 factory=groups.PairwiseFactorGroup,
-                connected_variable_names=binary_connected_variables(
-                    28, 28, k_row, k_col
-                ),
+                variable_names=binary_connected_variables(28, 28, k_row, k_col),
                 log_potential_matrix=W_pot[:, :, k_row, k_col],
                 name=(k_row, k_col),
             )

--- a/tests/test_pgmax.py
+++ b/tests/test_pgmax.py
@@ -350,14 +350,14 @@ def test_e2e_sanity_check():
     # Add the suppression factors to the graph via kwargs
     fg.add_factor_group(
         factory=groups.EnumerationFactorGroup,
-        connected_variable_names={
+        variable_names_for_factors={
             idx: names for idx, names in enumerate(vert_suppression_names)
         },
         factor_configs=valid_configs_supp,
     )
     fg.add_factor_group(
         factory=groups.EnumerationFactorGroup,
-        connected_variable_names=horz_suppression_names,
+        variable_names_for_factors=horz_suppression_names,
         factor_configs=valid_configs_supp,
         log_potentials=np.zeros(valid_configs_supp.shape[0], dtype=float),
     )
@@ -410,7 +410,7 @@ def test_e2e_heretic():
         for k_col in range(3):
             fg.add_factor_group(
                 factory=groups.PairwiseFactorGroup,
-                connected_variable_names=binary_connected_variables(
+                variable_names_for_factors=binary_connected_variables(
                     28, 28, k_row, k_col
                 ),
                 log_potential_matrix=W_pot[:, :, k_row, k_col],


### PR DESCRIPTION
Included a few naming updates: `variable_size` -> `num_state`, `connected_variable_names` -> `variable_name_for_factors`.

Updates on example notebooks from blog post writing.

Fixed a bug in factor group broadcasting.

Resolves https://github.com/vicariousinc/PGMax/issues/62. Resolves https://github.com/vicariousinc/PGMax/issues/66 (with the updated RBM example notebook). Resolves https://github.com/vicariousinc/PGMax/issues/105.