### PR TITLE
Fix offsets computation for messages/potentials; Support AND factor

### DIFF
--- a/pgmax/factors/__init__.py
+++ b/pgmax/factors/__init__.py
@@ -12,6 +12,7 @@ FAC_TO_VAR_UPDATES: OrderedDict[
 ] = collections.OrderedDict(
     [
         (enumeration.EnumerationFactor, enumeration.pass_enum_fac_to_var_messages),
-        (logical.ORFactor, logical.pass_OR_fac_to_var_messages),
+        (logical.ORFactor, logical.pass_logical_fac_to_var_messages),
+        (logical.ANDFactor, logical.pass_logical_fac_to_var_messages),
     ]
 )

--- a/pgmax/factors/logical.py
+++ b/pgmax/factors/logical.py
@@ -243,18 +243,22 @@ def pass_logical_fac_to_var_messages(
     log_potentials: Optional[jnp.ndarray] = None,
 ) -> jnp.ndarray:
 
-    """Passes messages from ORFactors to Variables.
+    """Passes messages from LogicalFactors to Variables.
 
     Args:
-        vtof_msgs: Array of shape (num_edge_state,). This holds all the flattened variable to all the ORFactors messages.
+        vtof_msgs: Array of shape (num_edge_state,). This holds all the flattened variable to all the LogicalFactors messages.
         parents_edge_states: Array of shape (num_parents, 2)
-            parents_edge_states[ii, 0] contains the global ORFactor index,
-            parents_edge_states[ii, 1] contains the message index of the parent variable's state 0.
-            Both indices only take into account the ORFactors of the FactorGraph
-            The parent variable's state 1 is parents_edge_states[ii, 2] + 1
+            parents_edge_states[ii, 0] contains the global LogicalFactor index,
+            parents_edge_states[ii, 1] contains the message index of the parent variable's relevant state.
+            For ORFactors the relevant state is 0, for ANDFactors the relevant state is 1.
+            Both indices only take into account the LogicalFactors of the FactorGraph
+            The parent variable's other state is parents_edge_states[ii, 2] + edge_states_offset
         children_edge_states: Array of shape (num_factors,)
-            children_edge_states[ii] contains the message index of the child variable's state 0
-            The child variable's state 1 is children_edge_states[ii, 1] + 1
+            children_edge_states[ii] contains the message index of the child variable's relevant state.
+            For ORFactors the relevant state is 0, for ANDFactors the relevant state is 1.
+            The child variable's other state is children_edge_states[ii, 1] + edge_states_offset
+        edge_states_offset: Offset to go from a variable's relevant state to its other state
+            For ORFactors the edge_states_offset is 1, for ANDFactors the edge_states_offset is -1.
         temperature: Temperature for loopy belief propagation.
             1.0 corresponds to sum-product, 0.0 corresponds to max-product.
 

--- a/pgmax/factors/logical.py
+++ b/pgmax/factors/logical.py
@@ -177,12 +177,12 @@ class ORFactor(LogicalFactor):
                 np.arange(0, 2 * num_parents, 2, dtype=int),
             ],
         ).T
-        child_edge_states = np.array([2 * num_parents], dtype=int)
+        child_edge_state = np.array([2 * num_parents], dtype=int)
         return LogicalWiring(
             edges_num_states=self.edges_num_states,
             var_states_for_edges=var_states_for_edges,
             parents_edge_states=parents_edge_states,
-            children_edge_states=child_edge_states,
+            children_edge_states=child_edge_state,
             edge_states_offset=1,
         )
 
@@ -223,12 +223,12 @@ class ANDFactor(LogicalFactor):
                 np.arange(1, 2 * num_parents, 2, dtype=int),
             ],
         ).T
-        child_edge_states = np.array([2 * num_parents + 1], dtype=int)
+        child_edge_state = np.array([2 * num_parents + 1], dtype=int)
         return LogicalWiring(
             edges_num_states=self.edges_num_states,
             var_states_for_edges=var_states_for_edges,
             parents_edge_states=parents_edge_states,
-            children_edge_states=child_edge_states,
+            children_edge_states=child_edge_state,
             edge_states_offset=-1,
         )
 

--- a/pgmax/factors/logical.py
+++ b/pgmax/factors/logical.py
@@ -154,7 +154,7 @@ class ORFactor(LogicalFactor):
     def compile_wiring(
         self, vars_to_starts: Mapping[nodes.Variable, int]
     ) -> LogicalWiring:
-        """Compile LogicalWiring for the LogicalFactor
+        """Compile LogicalWiring for the ORFactor
 
         Args:
             vars_to_starts: A dictionary that maps variables to their global starting indices
@@ -162,7 +162,7 @@ class ORFactor(LogicalFactor):
                 of its n variable states are m, m + 1, ..., m + n - 1
 
         Returns:
-             LogicalWiring for the LogicalFactor
+             LogicalWiring for the ORFactor
         """
         var_states_for_edges = np.concatenate(
             [
@@ -190,17 +190,17 @@ class ORFactor(LogicalFactor):
 @dataclass(frozen=True, eq=False)
 class ANDFactor(LogicalFactor):
     """An AND factor of the form (p1,...,pn, c)
-    where p1,...,pn are the parents variables and c is the child variable.
+        where p1,...,pn are the parents variables and c is the child variable.
 
-    An OR factor is defined as:
-    F(p1, p2, ..., pn, c) = 0 <=> c = OR(p1, p2, ..., pn)
-    F(p1, p2, ..., pn, c) = -inf o.w.
+    An AND factor is defined as:
+        F(p1, p2, ..., pn, c) = 0 <=> c = AND(p1, p2, ..., pn)
+        F(p1, p2, ..., pn, c) = -inf o.w.
     """
 
     def compile_wiring(
         self, vars_to_starts: Mapping[nodes.Variable, int]
     ) -> LogicalWiring:
-        """Compile LogicalWiring for the LogicalFactor
+        """Compile LogicalWiring for the ANDFactor
 
         Args:
             vars_to_starts: A dictionary that maps variables to their global starting indices
@@ -208,7 +208,7 @@ class ANDFactor(LogicalFactor):
                 of its n variable states are m, m + 1, ..., m + n - 1
 
         Returns:
-             LogicalWiring for the LogicalFactor
+             LogicalWiring for the ANDFactor
         """
         var_states_for_edges = np.concatenate(
             [

--- a/tests/factors/test_and.py
+++ b/tests/factors/test_and.py
@@ -13,12 +13,15 @@ def test_run_bp_with_AND_factors():
     (1) the support of ANDFactors in a factor graph inference and their specialized inference
     for different temperature
     (2) the support of several factor types in a factor graph and during inference
+
     To do so, observe that an ANDFactor can be defined as an equivalent EnumerationFactor
     (which list all the valid AND configurations) and define two equivalent factor graphs
     FG1: first half of factors are defined as EnumerationFactors, second half are defined as ANDFactors
     FG2: first half of factors are defined as ANDFactors, second half are defined as EnumerationFactors
+
     Inference for the EnumerationFactors will be run with pass_enum_fac_to_var_messages while
-    inference for the ANDFactors will be run with pass_OR_fac_to_var_messages.
+    inference for the ANDFactors will be run with pass_logical_fac_to_var_messages.
+
     Note: for the first seed, we add all the EnumerationFactors to FG1 and all the ANDFactors to FG2
     """
     for idx in range(10):

--- a/tests/factors/test_and.py
+++ b/tests/factors/test_and.py
@@ -1,0 +1,152 @@
+from itertools import product
+
+import jax
+import numpy as np
+
+from pgmax.factors import logical
+from pgmax.fg import graph, groups
+
+
+def test_run_bp_with_AND_factors():
+    """
+    Simultaneously test
+    (1) the support of ANDFactors in a factor graph inference and their specialized inference
+    for different temperature
+    (2) the support of several factor types in a factor graph and during inference
+    To do so, observe that an ANDFactor can be defined as an equivalent EnumerationFactor
+    (which list all the valid AND configurations) and define two equivalent factor graphs
+    FG1: first half of factors are defined as EnumerationFactors, second half are defined as ANDFactors
+    FG2: first half of factors are defined as ANDFactors, second half are defined as EnumerationFactors
+    Inference for the EnumerationFactors will be run with pass_enum_fac_to_var_messages while
+    inference for the ANDFactors will be run with pass_OR_fac_to_var_messages.
+    Note: for the first seed, we add all the EnumerationFactors to FG1 and all the ANDFactors to FG2
+    """
+    for idx in range(10):
+        np.random.seed(idx)
+
+        # Parameters
+        num_factors = np.random.randint(3, 8)
+        num_parents = np.random.randint(1, 6, num_factors)
+        num_parents_cumsum = np.insert(np.cumsum(num_parents), 0, 0)
+
+        # Setting the temperature
+        if idx % 2 == 0:
+            # Max-product
+            temperature = 0.0
+        else:
+            temperature = np.random.uniform(low=0.5, high=1.0)
+
+        # Graph 1
+        parents_variables1 = groups.NDVariableArray(
+            num_states=2, shape=(num_parents.sum(),)
+        )
+        children_variable1 = groups.NDVariableArray(num_states=2, shape=(num_factors,))
+        fg1 = graph.FactorGraph(
+            variables=dict(parents=parents_variables1, children=children_variable1)
+        )
+
+        # Graph 2
+        parents_variables2 = groups.NDVariableArray(
+            num_states=2, shape=(num_parents.sum(),)
+        )
+        children_variable2 = groups.NDVariableArray(num_states=2, shape=(num_factors,))
+        fg2 = graph.FactorGraph(
+            variables=dict(parents=parents_variables2, children=children_variable2)
+        )
+
+        # Option 1: Define EnumerationFactors equivalent to the ANDFactors
+        for factor_idx in range(num_factors):
+            this_num_parents = num_parents[factor_idx]
+            variable_names = [
+                ("parents", idx)
+                for idx in range(
+                    num_parents_cumsum[factor_idx],
+                    num_parents_cumsum[factor_idx + 1],
+                )
+            ] + [("children", factor_idx)]
+
+            configs = np.array(list(product([0, 1], repeat=this_num_parents + 1)))
+            # Children state is last
+            valid_AND_configs = configs[
+                np.logical_and(
+                    configs[:, :-1].sum(axis=1) < this_num_parents, configs[:, -1] == 0
+                )
+            ]
+            valid_configs = np.concatenate(
+                [np.ones((1, this_num_parents + 1), dtype=int), valid_AND_configs],
+                axis=0,
+            )
+            assert valid_configs.shape[0] == 2 ** this_num_parents
+
+            if factor_idx < num_factors // 2:
+                # Add the first half of factors to FactorGraph1
+                fg1.add_factor(
+                    variable_names=variable_names,
+                    factor_configs=valid_configs,
+                    log_potentials=np.zeros(valid_configs.shape[0]),
+                )
+            else:
+                if idx != 0:
+                    # Add the second half of factors to FactorGraph2
+                    fg2.add_factor(
+                        variable_names=variable_names,
+                        factor_configs=valid_configs,
+                        log_potentials=np.zeros(valid_configs.shape[0]),
+                    )
+                else:
+                    # Add all the EnumerationFactors to FactorGraph1 for the first iter
+                    fg1.add_factor(
+                        variable_names=variable_names,
+                        factor_configs=valid_configs,
+                        log_potentials=np.zeros(valid_configs.shape[0]),
+                    )
+
+        # Option 2: Define the ANDFactors
+        num_parents_cumsum = np.insert(np.cumsum(num_parents), 0, 0)
+        for factor_idx in range(num_factors):
+            variables_names_for_AND_factor = [
+                ("parents", idx)
+                for idx in range(
+                    num_parents_cumsum[factor_idx],
+                    num_parents_cumsum[factor_idx + 1],
+                )
+            ] + [("children", factor_idx)]
+
+            if factor_idx < num_factors // 2:
+                # Add the first half of factors to FactorGraph2
+                fg2.add_factor_by_type(
+                    variable_names=variables_names_for_AND_factor,
+                    factor_type=logical.ANDFactor,
+                )
+            else:
+                if idx != 0:
+                    # Add the second half of factors to FactorGraph1
+                    fg1.add_factor_by_type(
+                        variable_names=variables_names_for_AND_factor,
+                        factor_type=logical.ANDFactor,
+                    )
+                else:
+                    # Add all the ANDFactors to FactorGraph2 for the first iter
+                    fg2.add_factor_by_type(
+                        variable_names=variables_names_for_AND_factor,
+                        factor_type=logical.ANDFactor,
+                    )
+
+        # Run inference
+        run_bp1, _, get_beliefs1 = graph.BP(fg1.bp_state, 1, temperature)
+        run_bp2, _, get_beliefs2 = graph.BP(fg2.bp_state, 1, temperature)
+
+        evidence_updates = {
+            "parents": jax.device_put(np.random.gumbel(size=(sum(num_parents), 2))),
+            "children": jax.device_put(np.random.gumbel(size=(num_factors, 2))),
+        }
+
+        bp_arrays1 = run_bp1(evidence_updates=evidence_updates)
+        bp_arrays2 = run_bp2(evidence_updates=evidence_updates)
+
+        # Get beliefs
+        beliefs1 = get_beliefs1(bp_arrays1)
+        beliefs2 = get_beliefs2(bp_arrays2)
+
+        assert np.allclose(beliefs1["children"], beliefs2["children"], atol=1e-4)
+        assert np.allclose(beliefs1["parents"], beliefs2["parents"], atol=1e-4)

--- a/tests/factors/test_or.py
+++ b/tests/factors/test_or.py
@@ -19,7 +19,7 @@ def test_run_bp_with_OR_factors():
     FG2: first half of factors are defined as ORFactors, second half are defined as EnumerationFactors
 
     Inference for the EnumerationFactors will be run with pass_enum_fac_to_var_messages while
-    inference for the ORFactors will be run with pass_OR_fac_to_var_messages.
+    inference for the ORFactors will be run with pass_logical_fac_to_var_messages.
 
     Note: for the first seed, add all the EnumerationFactors to FG1 and all the ORFactors to FG2
     """

--- a/tests/fg/test_nodes.py
+++ b/tests/fg/test_nodes.py
@@ -109,3 +109,17 @@ def test_logical_factor():
             children_edge_states=child_edge_state,
             edge_states_offset=1,
         )
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "The LogicalWiring's edge_states_offset must be 1 (for OR) and -1 (for AND), but is 0"
+        ),
+    ):
+        logical.LogicalWiring(
+            edges_num_states=logical_factor.edges_num_states,
+            var_states_for_edges=None,
+            parents_edge_states=parents_edge_states,
+            children_edge_states=child_edge_state,
+            edge_states_offset=0,
+        )

--- a/tests/fg/test_nodes.py
+++ b/tests/fg/test_nodes.py
@@ -80,13 +80,22 @@ def test_logical_factor():
     logical_factor = logical.LogicalFactor(
         variables=(parent, child),
     )
+    num_parents = len(logical_factor.variables) - 1
+    parents_edge_states = np.vstack(
+        [
+            np.zeros(num_parents, dtype=int),
+            np.arange(0, 2 * num_parents, 2, dtype=int),
+        ],
+    ).T
+    child_edge_state = np.array([2 * num_parents], dtype=int)
 
     with pytest.raises(ValueError, match="The highest LogicalFactor index must be 0"):
         logical.LogicalWiring(
             edges_num_states=logical_factor.edges_num_states,
             var_states_for_edges=None,
-            parents_edge_states=logical_factor.parents_edge_states + np.array([[1, 0]]),
-            children_edge_states=logical_factor.child_edge_state,
+            parents_edge_states=parents_edge_states + np.array([[1, 0]]),
+            children_edge_states=child_edge_state,
+            edge_states_offset=1,
         )
 
     with pytest.raises(
@@ -96,7 +105,7 @@ def test_logical_factor():
         logical.LogicalWiring(
             edges_num_states=logical_factor.edges_num_states,
             var_states_for_edges=None,
-            parents_edge_states=logical_factor.parents_edge_states
-            + np.array([[0], [1]]),
-            children_edge_states=logical_factor.child_edge_state,
+            parents_edge_states=parents_edge_states + np.array([[0], [1]]),
+            children_edge_states=child_edge_state,
+            edge_states_offset=1,
         )


### PR DESCRIPTION
The messages and potentials offsets for factors/factor groups should not be done by type, since they are only used in updating messages/potentials which works with the whole flat array. This PR fixes it.

Also added support for AND factors by slightly tweaking the existing OR factor implementation.

Resolves https://github.com/vicariousinc/PGMax/issues/125