### PR TITLE
Variables refactor

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,10 +27,10 @@ repos:
         args: ['--config', '.flake8.config','--exit-zero']
         verbose: true
 
-# -   repo: https://github.com/pre-commit/mirrors-mypy
-#     rev: 'v0.942'  # Use the sha / tag you want to point at
-#     hooks:
-#     -   id: mypy
-#         additional_dependencies: [tokenize-rt==3.2.0]
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: 'v0.942'  # Use the sha / tag you want to point at
+    hooks:
+    -   id: mypy
+        additional_dependencies: [tokenize-rt==3.2.0]
 ci:
   autoupdate_schedule: 'quarterly'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,10 +27,10 @@ repos:
         args: ['--config', '.flake8.config','--exit-zero']
         verbose: true
 
--   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v0.942'  # Use the sha / tag you want to point at
-    hooks:
-    -   id: mypy
-        additional_dependencies: [tokenize-rt==3.2.0]
+# -   repo: https://github.com/pre-commit/mirrors-mypy
+#     rev: 'v0.942'  # Use the sha / tag you want to point at
+#     hooks:
+#     -   id: mypy
+#         additional_dependencies: [tokenize-rt==3.2.0]
 ci:
   autoupdate_schedule: 'quarterly'

--- a/examples/gmrf.py
+++ b/examples/gmrf.py
@@ -61,31 +61,39 @@ fg = graph.FactorGraph(variables)
 # Add top-down factors
 fg.add_factor_group(
     factory=enumeration.PairwiseFactorGroup,
-    variable_names_for_factors=[
-        [(ii, jj), (ii + 1, jj)] for ii in range(M - 1) for jj in range(N)
+    variables_for_factors=[
+        [variables[ii, jj], variables[ii + 1, jj]]
+        for ii in range(M - 1)
+        for jj in range(N)
     ],
     name="top_down",
 )
 # Add left-right factors
 fg.add_factor_group(
     factory=enumeration.PairwiseFactorGroup,
-    variable_names_for_factors=[
-        [(ii, jj), (ii, jj + 1)] for ii in range(M) for jj in range(N - 1)
+    variables_for_factors=[
+        [variables[ii, jj], variables[ii, jj + 1]]
+        for ii in range(M)
+        for jj in range(N - 1)
     ],
     name="left_right",
 )
 # Add diagonal factors
 fg.add_factor_group(
     factory=enumeration.PairwiseFactorGroup,
-    variable_names_for_factors=[
-        [(ii, jj), (ii + 1, jj + 1)] for ii in range(M - 1) for jj in range(N - 1)
+    variables_for_factors=[
+        [variables[ii, jj], variables[ii + 1, jj + 1]]
+        for ii in range(M - 1)
+        for jj in range(N - 1)
     ],
     name="diagonal0",
 )
 fg.add_factor_group(
     factory=enumeration.PairwiseFactorGroup,
-    variable_names_for_factors=[
-        [(ii, jj), (ii - 1, jj + 1)] for ii in range(1, M) for jj in range(N - 1)
+    variables_for_factors=[
+        [variables[ii, jj], variables[ii - 1, jj + 1]]
+        for ii in range(1, M)
+        for jj in range(N - 1)
     ],
     name="diagonal1",
 )
@@ -106,7 +114,7 @@ for plot_idx, idx in tqdm(enumerate(indices), total=n_plots):
         bp.get_beliefs(
             bp.run_bp(
                 bp.init(
-                    evidence_updates={None: evidence},
+                    evidence_updates={variables: evidence},
                     log_potentials_updates=log_potentials,
                 ),
                 num_iters=15,
@@ -114,6 +122,7 @@ for plot_idx, idx in tqdm(enumerate(indices), total=n_plots):
             )
         )
     )
+    marginals = marginals[variables]
     pred_image = np.argmax(
         np.stack(
             [
@@ -153,7 +162,7 @@ def loss(noisy_image, target_image, log_potentials):
         bp.get_beliefs(
             bp.run_bp(
                 bp.init(
-                    evidence_updates={None: evidence},
+                    evidence_updates={variables: evidence},
                     log_potentials_updates=log_potentials,
                 ),
                 num_iters=15,
@@ -161,7 +170,7 @@ def loss(noisy_image, target_image, log_potentials):
             )
         )
     )
-    logp = jnp.mean(jnp.log(jnp.sum(target * marginals, axis=-1)))
+    logp = jnp.mean(jnp.log(jnp.sum(target * marginals[variables], axis=-1)))
     return -logp
 
 

--- a/examples/gmrf.py
+++ b/examples/gmrf.py
@@ -88,7 +88,6 @@ factor_group = enumeration.PairwiseFactorGroup(
 )
 fg.add_factor_group(factor_group, name="diagonal0")
 
-
 factor_group = enumeration.PairwiseFactorGroup(
     variables_for_factors=[
         [variables[ii, jj], variables[ii - 1, jj + 1]]

--- a/examples/gmrf.py
+++ b/examples/gmrf.py
@@ -59,44 +59,44 @@ fg = graph.FactorGraph(variables)
 
 # %%
 # Add top-down factors
-fg.add_factor_group(
-    factory=enumeration.PairwiseFactorGroup,
+factor_group = enumeration.PairwiseFactorGroup(
     variables_for_factors=[
         [variables[ii, jj], variables[ii + 1, jj]]
         for ii in range(M - 1)
         for jj in range(N)
     ],
-    name="top_down",
 )
+fg.add_factor_group(factor_group, name="top_down")
+
 # Add left-right factors
-fg.add_factor_group(
-    factory=enumeration.PairwiseFactorGroup,
+factor_group = enumeration.PairwiseFactorGroup(
     variables_for_factors=[
         [variables[ii, jj], variables[ii, jj + 1]]
         for ii in range(M)
         for jj in range(N - 1)
     ],
-    name="left_right",
 )
+fg.add_factor_group(factor_group, name="left_right")
+
 # Add diagonal factors
-fg.add_factor_group(
-    factory=enumeration.PairwiseFactorGroup,
+factor_group = enumeration.PairwiseFactorGroup(
     variables_for_factors=[
         [variables[ii, jj], variables[ii + 1, jj + 1]]
         for ii in range(M - 1)
         for jj in range(N - 1)
     ],
-    name="diagonal0",
 )
-fg.add_factor_group(
-    factory=enumeration.PairwiseFactorGroup,
+fg.add_factor_group(factor_group, name="diagonal0")
+
+
+factor_group = enumeration.PairwiseFactorGroup(
     variables_for_factors=[
         [variables[ii, jj], variables[ii - 1, jj + 1]]
         for ii in range(1, M)
         for jj in range(N - 1)
     ],
-    name="diagonal1",
 )
+fg.add_factor_group(factor_group, name="diagonal1")
 
 # %%
 bp = graph.BP(fg.bp_state, temperature=1.0)
@@ -227,3 +227,12 @@ with tqdm(total=n_epochs * n_batches) as pbar:
             )
             pbar.update()
             pbar.set_postfix(loss=value)
+
+
+batch_indices = indices[idx * batch_size : (idx + 1) * batch_size]
+batch_noisy_images, batch_target_images = (
+    noisy_images_train[:10],
+    target_images_train[:10],
+)
+step = 0
+value, opt_state = update(step, batch_noisy_images, batch_target_images, opt_state)

--- a/examples/gmrf.py
+++ b/examples/gmrf.py
@@ -121,8 +121,8 @@ for plot_idx, idx in tqdm(enumerate(indices), total=n_plots):
                 damping=0.0,
             )
         )
-    )
-    marginals = marginals[variables]
+    )[variables]
+
     pred_image = np.argmax(
         np.stack(
             [

--- a/examples/gmrf.py
+++ b/examples/gmrf.py
@@ -66,7 +66,7 @@ top_down = enumeration.PairwiseFactorGroup(
         for jj in range(N)
     ],
 )
-fg.add_factor_group(top_down)
+fg.add_factors(top_down)
 
 # Add left-right factors
 left_right = enumeration.PairwiseFactorGroup(
@@ -76,7 +76,7 @@ left_right = enumeration.PairwiseFactorGroup(
         for jj in range(N - 1)
     ],
 )
-fg.add_factor_group(left_right)
+fg.add_factors(left_right)
 
 # Add diagonal factors
 diagonal0 = enumeration.PairwiseFactorGroup(
@@ -86,7 +86,7 @@ diagonal0 = enumeration.PairwiseFactorGroup(
         for jj in range(N - 1)
     ],
 )
-fg.add_factor_group(diagonal0)
+fg.add_factors(diagonal0)
 
 diagonal1 = enumeration.PairwiseFactorGroup(
     variables_for_factors=[
@@ -95,7 +95,7 @@ diagonal1 = enumeration.PairwiseFactorGroup(
         for jj in range(N - 1)
     ],
 )
-fg.add_factor_group(diagonal1)
+fg.add_factors(diagonal1)
 
 # %%
 bp = graph.BP(fg.bp_state, temperature=1.0)

--- a/examples/gmrf.py
+++ b/examples/gmrf.py
@@ -58,7 +58,7 @@ variables = vgroup.NDVariableArray(num_states=num_states, shape=(M, N))
 fg = graph.FactorGraph(variables)
 
 # %%
-# Add top-down factors
+# Create top-down factors
 top_down = enumeration.PairwiseFactorGroup(
     variables_for_factors=[
         [variables[ii, jj], variables[ii + 1, jj]]
@@ -66,9 +66,8 @@ top_down = enumeration.PairwiseFactorGroup(
         for jj in range(N)
     ],
 )
-fg.add_factors(top_down)
 
-# Add left-right factors
+# Create left-right factors
 left_right = enumeration.PairwiseFactorGroup(
     variables_for_factors=[
         [variables[ii, jj], variables[ii, jj + 1]]
@@ -76,9 +75,8 @@ left_right = enumeration.PairwiseFactorGroup(
         for jj in range(N - 1)
     ],
 )
-fg.add_factors(left_right)
 
-# Add diagonal factors
+# Create diagonal factors
 diagonal0 = enumeration.PairwiseFactorGroup(
     variables_for_factors=[
         [variables[ii, jj], variables[ii + 1, jj + 1]]
@@ -86,8 +84,6 @@ diagonal0 = enumeration.PairwiseFactorGroup(
         for jj in range(N - 1)
     ],
 )
-fg.add_factors(diagonal0)
-
 diagonal1 = enumeration.PairwiseFactorGroup(
     variables_for_factors=[
         [variables[ii, jj], variables[ii - 1, jj + 1]]
@@ -95,7 +91,9 @@ diagonal1 = enumeration.PairwiseFactorGroup(
         for jj in range(N - 1)
     ],
 )
-fg.add_factors(diagonal1)
+
+# Add factors
+fg.add_factors([top_down, left_right, diagonal0, diagonal1])
 
 # %%
 bp = graph.BP(fg.bp_state, temperature=1.0)

--- a/examples/gmrf.py
+++ b/examples/gmrf.py
@@ -233,11 +233,3 @@ with tqdm(total=n_epochs * n_batches) as pbar:
             )
             pbar.update()
             pbar.set_postfix(loss=value)
-
-batch_indices = indices[idx * batch_size : (idx + 1) * batch_size]
-batch_noisy_images, batch_target_images = (
-    noisy_images_train[:10],
-    target_images_train[:10],
-)
-step = 0
-value, opt_state = update(step, batch_noisy_images, batch_target_images, opt_state)

--- a/examples/ising_model.py
+++ b/examples/ising_model.py
@@ -29,7 +29,7 @@ from pgmax.groups import variables as vgroup
 
 # %%
 variables = vgroup.NDVariableArray(num_states=2, shape=(50, 50))
-fg = graph.FactorGraph(variables=variables)
+fg = graph.FactorGraph(variable_groups=variables)
 
 variables_for_factors = []
 for ii in range(50):
@@ -43,7 +43,7 @@ factor_group = enumeration.PairwiseFactorGroup(
     variables_for_factors=variables_for_factors,
     log_potential_matrix=0.8 * np.array([[1.0, -1.0], [-1.0, 1.0]]),
 )
-fg.add_factor_group(factor_group)
+fg.add_factors(factor_group)
 
 # %% [markdown]
 # ### Run inference and visualize results

--- a/examples/ising_model.py
+++ b/examples/ising_model.py
@@ -39,12 +39,11 @@ for ii in range(50):
         variables_for_factors.append([variables[ii, jj], variables[kk, jj]])
         variables_for_factors.append([variables[ii, jj], variables[kk, ll]])
 
-fg.add_factor_group(
-    factory=enumeration.PairwiseFactorGroup,
+factor_group = enumeration.PairwiseFactorGroup(
     variables_for_factors=variables_for_factors,
     log_potential_matrix=0.8 * np.array([[1.0, -1.0], [-1.0, 1.0]]),
-    name="factors",
 )
+fg.add_factor_group(factor_group, name="factors")
 
 # %% [markdown]
 # ### Run inference and visualize results

--- a/examples/ising_model.py
+++ b/examples/ising_model.py
@@ -46,25 +46,19 @@ fg.add_factor_group(
     log_potential_matrix=0.8 * np.array([[1.0, -1.0], [-1.0, 1.0]]),
 )
 
-# %%
-from pgmax.factors import enumeration as enumeration_factor
-
-factors = fg.factor_groups[enumeration_factor.EnumerationFactor][0].factors
-
 # %% [markdown]
 # ### Run inference and visualize results
 
-import imp
-
 # %%
-from pgmax.fg import graph
-
-imp.reload(graph)
 bp = graph.BP(fg.bp_state, temperature=0)
 
 # %%
+d = {variables: 1, variables.__hash__(): 2}
+hd = graph.HashableDict(d)
+hd[variables]
+
+# %%
 # TODO: check\ time for before BP vs time for BP
-# TODO: why bug when done twice?
 # TODO: time PGMAX vs PMP
 bp_arrays = bp.init(
     evidence_updates={variables: jax.device_put(np.random.gumbel(size=(50, 50, 2)))}

--- a/examples/ising_model.py
+++ b/examples/ising_model.py
@@ -43,7 +43,7 @@ factor_group = enumeration.PairwiseFactorGroup(
     variables_for_factors=variables_for_factors,
     log_potential_matrix=0.8 * np.array([[1.0, -1.0], [-1.0, 1.0]]),
 )
-fg.add_factor_group(factor_group, name="factors")
+fg.add_factor_group(factor_group)
 
 # %% [markdown]
 # ### Run inference and visualize results
@@ -88,7 +88,7 @@ batch_loss(None, {variables: jax.device_put(np.random.gumbel(size=(10, 50, 50, 2
 
 # %%
 grads = log_potentials_grads(
-    {"factors": jnp.eye(2)},
+    {factor_group: jnp.eye(2)},
     {variables: jax.device_put(np.random.gumbel(size=(50, 50, 2)))},
 )
 

--- a/examples/ising_model.py
+++ b/examples/ising_model.py
@@ -37,7 +37,7 @@ for ii in range(50):
         kk = (ii + 1) % 50
         ll = (jj + 1) % 50
         variables_for_factors.append([variables[ii, jj], variables[kk, jj]])
-        variables_for_factors.append([variables[ii, jj], variables[kk, ll]])
+        variables_for_factors.append([variables[ii, jj], variables[ii, ll]])
 
 factor_group = enumeration.PairwiseFactorGroup(
     variables_for_factors=variables_for_factors,
@@ -52,8 +52,6 @@ fg.add_factors(factor_group)
 bp = graph.BP(fg.bp_state, temperature=0)
 
 # %%
-# TODO: check\ time for before BP vs time for BP
-# TODO: time PGMAX vs PMP
 bp_arrays = bp.init(
     evidence_updates={variables: jax.device_put(np.random.gumbel(size=(50, 50, 2)))}
 )

--- a/examples/ising_model.py
+++ b/examples/ising_model.py
@@ -31,19 +31,19 @@ from pgmax.groups import variables as vgroup
 variables = vgroup.NDVariableArray(num_states=2, shape=(50, 50))
 fg = graph.FactorGraph(variables=variables)
 
-# TODO: rename variable_for_factors?
-variable_names_for_factors = []
+variables_for_factors = []
 for ii in range(50):
     for jj in range(50):
         kk = (ii + 1) % 50
         ll = (jj + 1) % 50
-        variable_names_for_factors.append([variables[ii, jj], variables[kk, jj]])
-        variable_names_for_factors.append([variables[ii, jj], variables[kk, ll]])
+        variables_for_factors.append([variables[ii, jj], variables[kk, jj]])
+        variables_for_factors.append([variables[ii, jj], variables[kk, ll]])
 
 fg.add_factor_group(
     factory=enumeration.PairwiseFactorGroup,
-    variable_names_for_factors=variable_names_for_factors,
+    variables_for_factors=variables_for_factors,
     log_potential_matrix=0.8 * np.array([[1.0, -1.0], [-1.0, 1.0]]),
+    name="factors",
 )
 
 # %% [markdown]
@@ -53,21 +53,16 @@ fg.add_factor_group(
 bp = graph.BP(fg.bp_state, temperature=0)
 
 # %%
-d = {variables: 1, variables.__hash__(): 2}
-hd = graph.HashableDict(d)
-hd[variables]
-
-# %%
 # TODO: check\ time for before BP vs time for BP
 # TODO: time PGMAX vs PMP
 bp_arrays = bp.init(
     evidence_updates={variables: jax.device_put(np.random.gumbel(size=(50, 50, 2)))}
 )
 bp_arrays = bp.run_bp(bp_arrays, num_iters=3000)
-output = bp.get_bp_output(bp_arrays)
+beliefs = bp.get_beliefs(bp_arrays)
 
 # %%
-img = output.map_states[variables]
+img = graph.decode_map_states(beliefs)[variables]
 fig, ax = plt.subplots(1, 1, figsize=(10, 10))
 ax.imshow(img)
 
@@ -82,19 +77,20 @@ def loss(log_potentials_updates, evidence_updates):
     )
     bp_arrays = bp.run_bp(bp_arrays, num_iters=3000)
     beliefs = bp.get_beliefs(bp_arrays)
-    loss = -jnp.sum(beliefs)
+    loss = -jnp.sum(beliefs[variables])
     return loss
 
 
-batch_loss = jax.jit(jax.vmap(loss, in_axes=(None, {None: 0}), out_axes=0))
+batch_loss = jax.jit(jax.vmap(loss, in_axes=(None, {variables: 0}), out_axes=0))
 log_potentials_grads = jax.jit(jax.grad(loss, argnums=0))
 
 # %%
-batch_loss(None, {None: jax.device_put(np.random.gumbel(size=(10, 50, 50, 2)))})
+batch_loss(None, {variables: jax.device_put(np.random.gumbel(size=(10, 50, 50, 2)))})
 
 # %%
 grads = log_potentials_grads(
-    {"factors": jnp.eye(2)}, {None: jax.device_put(np.random.gumbel(size=(50, 50, 2)))}
+    {"factors": jnp.eye(2)},
+    {variables: jax.device_put(np.random.gumbel(size=(50, 50, 2)))},
 )
 
 # %% [markdown]
@@ -104,15 +100,15 @@ grads = log_potentials_grads(
 bp_state = bp.to_bp_state(bp_arrays)
 
 # Query evidence for variable (0, 0)
-bp_state.evidence[0, 0]
+bp_state.evidence[variables[0, 0]]
 
 # %%
 # Set evidence for variable (0, 0)
-bp_state.evidence[0, 0] = np.array([1.0, 1.0])
-bp_state.evidence[0, 0]
+bp_state.evidence[variables[0, 0]] = np.array([1.0, 1.0])
+bp_state.evidence[variables[0, 0]]
 
 # %%
 # Set evidence for all variables using an array
 evidence = np.random.randn(50, 50, 2)
-bp_state.evidence[None] = evidence
-bp_state.evidence[10, 10] == evidence[10, 10]
+bp_state.evidence[variables] = evidence
+np.allclose(bp_state.evidence[variables[10, 10]], evidence[10, 10])

--- a/examples/ising_model.py
+++ b/examples/ising_model.py
@@ -30,35 +30,50 @@ from pgmax.groups import variables as vgroup
 # %%
 variables = vgroup.NDVariableArray(num_states=2, shape=(50, 50))
 fg = graph.FactorGraph(variables=variables)
+
+# TODO: rename variable_for_factors?
 variable_names_for_factors = []
 for ii in range(50):
     for jj in range(50):
         kk = (ii + 1) % 50
         ll = (jj + 1) % 50
-        variable_names_for_factors.append([(ii, jj), (kk, jj)])
-        variable_names_for_factors.append([(ii, jj), (ii, ll)])
+        variable_names_for_factors.append([variables[ii, jj], variables[kk, jj]])
+        variable_names_for_factors.append([variables[ii, jj], variables[kk, ll]])
 
 fg.add_factor_group(
     factory=enumeration.PairwiseFactorGroup,
     variable_names_for_factors=variable_names_for_factors,
     log_potential_matrix=0.8 * np.array([[1.0, -1.0], [-1.0, 1.0]]),
-    name="factors",
 )
+
+# %%
+from pgmax.factors import enumeration as enumeration_factor
+
+factors = fg.factor_groups[enumeration_factor.EnumerationFactor][0].factors
 
 # %% [markdown]
 # ### Run inference and visualize results
 
+import imp
+
 # %%
+from pgmax.fg import graph
+
+imp.reload(graph)
 bp = graph.BP(fg.bp_state, temperature=0)
 
 # %%
+# TODO: check\ time for before BP vs time for BP
+# TODO: why bug when done twice?
+# TODO: time PGMAX vs PMP
 bp_arrays = bp.init(
-    evidence_updates={None: jax.device_put(np.random.gumbel(size=(50, 50, 2)))}
+    evidence_updates={variables: jax.device_put(np.random.gumbel(size=(50, 50, 2)))}
 )
 bp_arrays = bp.run_bp(bp_arrays, num_iters=3000)
+output = bp.get_bp_output(bp_arrays)
 
 # %%
-img = graph.decode_map_states(bp.get_beliefs(bp_arrays))
+img = output.map_states[variables]
 fig, ax = plt.subplots(1, 1, figsize=(10, 10))
 ax.imshow(img)
 

--- a/examples/pmp_binary_deconvolution.py
+++ b/examples/pmp_binary_deconvolution.py
@@ -224,7 +224,7 @@ print("Time", time.time() - start)
 
 # %%
 pW = 0.25
-pS = 1e-72
+pS = 1e-80
 pX = 1e-100
 
 # Sparsity inducing priors for W and S
@@ -242,7 +242,7 @@ uX[..., 0] = (2 * X_gt - 1) * logit(pX)
 # We draw a batch of samples from the posterior in parallel by transforming `run_bp`/`get_beliefs` with `jax.vmap`
 
 # %%
-np.random.seed(seed=40)
+np.random.seed(seed=42)
 n_samples = 4
 
 start = time.time()
@@ -271,3 +271,5 @@ map_states = graph.decode_map_states(beliefs)
 
 # %%
 _ = plot_images(map_states[W].reshape(-1, feat_height, feat_width), nr=n_samples)
+
+# %%

--- a/examples/pmp_binary_deconvolution.py
+++ b/examples/pmp_binary_deconvolution.py
@@ -195,7 +195,7 @@ OR_factor_group = logical.ORFactorGroup(variables_for_ORFactors)
 fg.add_factors(OR_factor_group)
 print("Time", time.time() - start)
 
-for factor_type, factor_groups in fg._factor_types_to_groups.items():
+for factor_type, factor_groups in fg.factor_groups.items():
     if len(factor_groups) > 0:
         assert len(factor_groups) == 1
         print(f"The factor graph contains {factor_groups[0].num_factors} {factor_type}")

--- a/examples/pmp_binary_deconvolution.py
+++ b/examples/pmp_binary_deconvolution.py
@@ -107,13 +107,7 @@ _ = plot_images(W_gt[0], nr=1)
 #
 # See Section 5.6 of the [PMP paper](https://proceedings.neurips.cc/paper/2021/hash/07b1c04a30f798b5506c1ec5acfb9031-Abstract.html) for more details.
 
-import imp
-
 # %%
-from pgmax.fg import graph
-
-imp.reload(graph)
-
 # The dimensions of W used for the generation of X were (4, 5, 5) but we set them to (5, 6, 6)
 # to simulate a more realistic scenario in which we do not know their ground truth values
 n_feat, feat_height, feat_width = 5, 6, 6
@@ -183,7 +177,7 @@ for idx_img in tqdm(range(n_images)):
 
                             X_var = X[idx_img, idx_chan, idx_img_height, idx_img_width]
                             variables_for_ORFactors_dict[X_var].append(SW_var)
-print(time.time() - start)
+print("After loop", time.time() - start)
 
 # Add ANDFactorGroup, which is computationally efficient
 fg.add_factor_group(

--- a/examples/pmp_binary_deconvolution.py
+++ b/examples/pmp_binary_deconvolution.py
@@ -138,12 +138,12 @@ X = vgroup.NDVariableArray(num_states=2, shape=X_gt.shape)
 print("Time", time.time() - start)
 
 # %% [markdown]
-# For computation efficiency, we add large FactorGroups via `fg.add_factor_group` instead of adding individual Factors
+# For computation efficiency, we add large FactorGroups via `fg.add_factors` instead of adding individual Factors
 
 # %%
 start = time.time()
 # Factor graph
-fg = graph.FactorGraph(variables=[S, W, SW, X])
+fg = graph.FactorGraph(variable_groups=[S, W, SW, X])
 print(time.time() - start)
 
 # Define the ANDFactors
@@ -181,7 +181,7 @@ print("After loop", time.time() - start)
 
 # Add ANDFactorGroup, which is computationally efficient
 AND_factor_group = logical.ANDFactorGroup(variables_for_ANDFactors)
-fg.add_factor_group(AND_factor_group)
+fg.add_factors(AND_factor_group)
 print(time.time() - start)
 
 # Define the ORFactors
@@ -192,7 +192,7 @@ variables_for_ORFactors = [
 
 # Add ORFactorGroup, which is computationally efficient
 OR_factor_group = logical.ORFactorGroup(variables_for_ORFactors)
-fg.add_factor_group(OR_factor_group)
+fg.add_factors(OR_factor_group)
 print("Time", time.time() - start)
 
 for factor_type, factor_groups in fg._factor_types_to_groups.items():

--- a/examples/pmp_binary_deconvolution.py
+++ b/examples/pmp_binary_deconvolution.py
@@ -180,10 +180,8 @@ for idx_img in tqdm(range(n_images)):
 print("After loop", time.time() - start)
 
 # Add ANDFactorGroup, which is computationally efficient
-fg.add_factor_group(
-    factory=logical.ANDFactorGroup,
-    variables_for_factors=variables_for_ANDFactors,
-)
+AND_factor_group = logical.ANDFactorGroup(variables_for_ANDFactors)
+fg.add_factor_group(AND_factor_group)
 print(time.time() - start)
 
 # Define the ORFactors
@@ -193,10 +191,8 @@ variables_for_ORFactors = [
 ]
 
 # Add ORFactorGroup, which is computationally efficient
-fg.add_factor_group(
-    factory=logical.ORFactorGroup,
-    variables_for_factors=variables_for_ORFactors,
-)
+OR_factor_group = logical.ORFactorGroup(variables_for_ORFactors)
+fg.add_factor_group(OR_factor_group)
 print("Time", time.time() - start)
 
 for factor_type, factor_groups in fg.factor_groups.items():
@@ -224,7 +220,7 @@ print("Time", time.time() - start)
 
 # %%
 pW = 0.25
-pS = 1e-80
+pS = 1e-70
 pX = 1e-100
 
 # Sparsity inducing priors for W and S
@@ -271,5 +267,3 @@ map_states = graph.decode_map_states(beliefs)
 
 # %%
 _ = plot_images(map_states[W].reshape(-1, feat_height, feat_width), nr=n_samples)
-
-# %%

--- a/examples/pmp_binary_deconvolution.py
+++ b/examples/pmp_binary_deconvolution.py
@@ -211,7 +211,6 @@ for factor_type, factor_groups in fg._factor_types_to_groups.items():
 # in the same manner does not change X, so this naturally results in multiple equivalent modes.
 
 # %%
-# %load_ext snakeviz
 start = time.time()
 bp = graph.BP(fg.bp_state, temperature=0.0)
 print("Time", time.time() - start)

--- a/examples/pmp_binary_deconvolution.py
+++ b/examples/pmp_binary_deconvolution.py
@@ -108,6 +108,8 @@ _ = plot_images(W_gt[0], nr=1)
 # See Section 5.6 of the [PMP paper](https://proceedings.neurips.cc/paper/2021/hash/07b1c04a30f798b5506c1ec5acfb9031-Abstract.html) for more details.
 #
 # import imp
+#
+# import imp
 
 import imp
 

--- a/examples/pmp_binary_deconvolution.py
+++ b/examples/pmp_binary_deconvolution.py
@@ -138,7 +138,7 @@ X = vgroup.NDVariableArray(num_states=2, shape=X_gt.shape)
 print("Time", time.time() - start)
 
 # %% [markdown]
-# For computation efficiency, we add large FactorGroups via `fg.add_factors` instead of adding individual Factors
+# For computation efficiency, we construct large FactorGroups instead of individual Factors
 
 # %%
 start = time.time()

--- a/examples/pmp_binary_deconvolution.py
+++ b/examples/pmp_binary_deconvolution.py
@@ -211,6 +211,7 @@ for factor_type, factor_groups in fg._factor_types_to_groups.items():
 # in the same manner does not change X, so this naturally results in multiple equivalent modes.
 
 # %%
+# %load_ext snakeviz
 start = time.time()
 bp = graph.BP(fg.bp_state, temperature=0.0)
 print("Time", time.time() - start)

--- a/examples/pmp_binary_deconvolution.py
+++ b/examples/pmp_binary_deconvolution.py
@@ -220,7 +220,7 @@ print("Time", time.time() - start)
 
 # %%
 pW = 0.25
-pS = 1e-70
+pS = 1e-100
 pX = 1e-100
 
 # Sparsity inducing priors for W and S

--- a/examples/pmp_binary_deconvolution.py
+++ b/examples/pmp_binary_deconvolution.py
@@ -195,7 +195,7 @@ OR_factor_group = logical.ORFactorGroup(variables_for_ORFactors)
 fg.add_factor_group(OR_factor_group)
 print("Time", time.time() - start)
 
-for factor_type, factor_groups in fg.factor_groups.items():
+for factor_type, factor_groups in fg._factor_types_to_groups.items():
     if len(factor_groups) > 0:
         assert len(factor_groups) == 1
         print(f"The factor graph contains {factor_groups[0].num_factors} {factor_type}")

--- a/examples/rbm.py
+++ b/examples/rbm.py
@@ -82,16 +82,17 @@ fg.add_factors(visible_unaries)
 log_potential_matrix = np.zeros(W.shape + (2, 2)).reshape((-1, 2, 2))
 log_potential_matrix[:, 1, 1] = W.ravel()
 
+variables_for_factors = [
+    [hidden_variables[ii], visible_variables[jj]]
+    for ii in range(bh.shape[0])
+    for jj in range(bv.shape[0])
+]
+print("Time", time.time() - start)
 pairwise_factors = enumeration.PairwiseFactorGroup(
-    variables_for_factors=[
-        [hidden_variables[ii], visible_variables[jj]]
-        for ii in range(bh.shape[0])
-        for jj in range(bv.shape[0])
-    ],
+    variables_for_factors=variables_for_factors,
     log_potential_matrix=log_potential_matrix,
 )
 print("Time", time.time() - start)
-# #%snakeviz pairwise_factors = enumeration.PairwiseFactorGroup(variables_for_factors=[ [hidden_variables[ii], visible_variables[jj]] for ii in range(bh.shape[0]) for jj in range(bv.shape[0])],log_potential_matrix=log_potential_matrix,)
 
 fg.add_factors(pairwise_factors)
 print("Time", time.time() - start)

--- a/examples/rbm.py
+++ b/examples/rbm.py
@@ -146,10 +146,6 @@ fg.add_factors([hidden_unaries, visible_unaries, pairwise_factors])
 # More generally, PGMax implements LBP with temperature, with `temperature=0.0` and `temperature=1.0` corresponding to the commonly used max/sum-product LBP respectively.
 #
 # Now we are ready to demonstrate PMP sampling from RBM. PMP perturbs the model with [Gumbel](https://numpy.org/doc/stable/reference/random/generated/numpy.random.gumbel.html) unary potentials, and draws a sample from the RBM as the MAP decoding from running max-product LBP on the perturbed model
-#
-# import itertools
-#
-# from tqdm import tqdm
 
 # %%
 bp = graph.BP(fg.bp_state, temperature=0.0)

--- a/examples/rbm.py
+++ b/examples/rbm.py
@@ -90,9 +90,10 @@ pairwise_factors = enumeration.PairwiseFactorGroup(
     ],
     log_potential_matrix=log_potential_matrix,
 )
-fg.add_factors(pairwise_factors)
+print("Time", time.time() - start)
+# #%snakeviz pairwise_factors = enumeration.PairwiseFactorGroup(variables_for_factors=[ [hidden_variables[ii], visible_variables[jj]] for ii in range(bh.shape[0]) for jj in range(bv.shape[0])],log_potential_matrix=log_potential_matrix,)
 
-# # %snakeviz fg.add_factors(factory=enumeration.PairwiseFactorGroup, variables_for_factors=v, log_potential_matrix=log_potential_matrix,)
+fg.add_factors(pairwise_factors)
 print("Time", time.time() - start)
 
 

--- a/examples/rbm.py
+++ b/examples/rbm.py
@@ -44,8 +44,8 @@ W = params["W"]
 
 # %% [markdown]
 # We can then initialize the factor graph for the RBM with
-
-import imp
+#
+# import imp
 
 # %%
 from pgmax.fg import graph

--- a/examples/rbm.py
+++ b/examples/rbm.py
@@ -44,6 +44,8 @@ W = params["W"]
 
 # %% [markdown]
 # We can then initialize the factor graph for the RBM with
+#
+# import imp
 
 import imp
 

--- a/examples/rbm.py
+++ b/examples/rbm.py
@@ -110,14 +110,14 @@ print("Time", time.time() - start)
 # # Add unary factors
 # for ii in range(bh.shape[0]):
 #     fg.add_factor(
-#         variable_names=[("hidden", ii)],
+#         variables=[hidden_variables[ii]],
 #         factor_configs=np.arange(2)[:, None],
 #         log_potentials=np.array([0, bh[ii]]),
 #     )
 #
 # for jj in range(bv.shape[0]):
 #     fg.add_factor(
-#         variable_names=[("visible", jj)],
+#         variables=[visible_variables[jj]],
 #         factor_configs=np.arange(2)[:, None],
 #         log_potentials=np.array([0, bv[jj]]),
 #     )
@@ -127,7 +127,7 @@ print("Time", time.time() - start)
 # for ii in tqdm(range(bh.shape[0])):
 #     for jj in range(bv.shape[0]):
 #         fg.add_factor(
-#             variable_names=[("hidden", ii), ("visible", jj)],
+#             variables=[hidden_variables[ii], visible_variables[jj]],
 #             factor_configs=factor_configs,
 #             log_potentials=np.array([0, 0, 0, W[ii, jj]]),
 #         )

--- a/examples/rbm.py
+++ b/examples/rbm.py
@@ -26,7 +26,6 @@ import jax
 import matplotlib.pyplot as plt
 import numpy as np
 
-from pgmax.factors import enumeration as enumeration_factor
 from pgmax.fg import graph
 from pgmax.groups import enumeration
 from pgmax.groups import variables as vgroup

--- a/examples/rbm.py
+++ b/examples/rbm.py
@@ -46,37 +46,30 @@ W = params["W"]
 # We can then initialize the factor graph for the RBM with
 
 # %%
-import time
-
-start = time.time()
 # Initialize factor graph
 hidden_variables = vgroup.NDVariableArray(num_states=2, shape=bh.shape)
 visible_variables = vgroup.NDVariableArray(num_states=2, shape=bv.shape)
 fg = graph.FactorGraph(variable_groups=[hidden_variables, visible_variables])
-print("Time", time.time() - start)
 
 # %% [markdown]
 # [`NDVariableArray`](https://pgmax.readthedocs.io/en/latest/_autosummary/pgmax.fg.groups.NDVariableArray.html#pgmax.fg.groups.NDVariableArray) is a convenient class for specifying a group of variables living on a multidimensional grid with the same number of states, and shares some similarities with [`numpy.ndarray`](https://numpy.org/doc/stable/reference/generated/numpy.ndarray.html). The [`FactorGraph`](https://pgmax.readthedocs.io/en/latest/_autosummary/pgmax.fg.graph.FactorGraph.html#pgmax.fg.graph.FactorGraph) `fg` is initialized with a set of variables, which can be either a single [`VariableGroup`](https://pgmax.readthedocs.io/en/latest/_autosummary/pgmax.fg.groups.VariableGroup.html#pgmax.fg.groups.VariableGroup) (e.g. an [`NDVariableArray`](https://pgmax.readthedocs.io/en/latest/_autosummary/pgmax.fg.groups.NDVariableArray.html#pgmax.fg.groups.NDVariableArray)), or a list/dictionary of [`VariableGroup`](https://pgmax.readthedocs.io/en/latest/_autosummary/pgmax.fg.groups.VariableGroup.html#pgmax.fg.groups.VariableGroup)s. Once initialized, the set of variables in `fg` is fixed and cannot be changed.
 #
-# After initialization, `fg` does not have any factors. PGMax supports imperatively adding factors to a [`FactorGraph`](https://pgmax.readthedocs.io/en/latest/_autosummary/pgmax.fg.graph.FactorGraph.html#pgmax.fg.graph.FactorGraph). We can add the unary and pairwise factors by grouping them using
+# After initialization, `fg` does not have any factors. PGMax supports imperatively adding factors to a [`FactorGraph`](https://pgmax.readthedocs.io/en/latest/_autosummary/pgmax.fg.graph.FactorGraph.html#pgmax.fg.graph.FactorGraph). We can add the unary and pairwise factors by grouping them using [`FactorGroup`](https://pgmax.readthedocs.io/en/latest/_autosummary/pgmax.fg.groups.FactorGroup.html#pgmax.fg.groups.FactorGroup)
 
 # %%
-start = time.time()
-
-# Add unary factors
+# Create unary factors
 hidden_unaries = enumeration.EnumerationFactorGroup(
     variables_for_factors=[[hidden_variables[ii]] for ii in range(bh.shape[0])],
     factor_configs=np.arange(2)[:, None],
     log_potentials=np.stack([np.zeros_like(bh), bh], axis=1),
 )
-
 visible_unaries = enumeration.EnumerationFactorGroup(
     variables_for_factors=[[visible_variables[jj]] for jj in range(bv.shape[0])],
     factor_configs=np.arange(2)[:, None],
     log_potentials=np.stack([np.zeros_like(bv), bv], axis=1),
 )
 
-# Add pairwise factors
+# Create pairwise factors
 log_potential_matrix = np.zeros(W.shape + (2, 2)).reshape((-1, 2, 2))
 log_potential_matrix[:, 1, 1] = W.ravel()
 
@@ -85,25 +78,23 @@ variables_for_factors = [
     for ii in range(bh.shape[0])
     for jj in range(bv.shape[0])
 ]
-print("Time", time.time() - start)
 pairwise_factors = enumeration.PairwiseFactorGroup(
     variables_for_factors=variables_for_factors,
     log_potential_matrix=log_potential_matrix,
 )
-print("Time", time.time() - start)
 
+# Add factors to the FactorGraph
 fg.add_factors([hidden_unaries, visible_unaries, pairwise_factors])
-print("Time", time.time() - start)
 
 
 # %% [markdown]
-# PGMax implements convenient and computationally efficient [`FactorGroup`](https://pgmax.readthedocs.io/en/latest/_autosummary/pgmax.fg.groups.FactorGroup.html#pgmax.fg.groups.FactorGroup) for representing Groups of similar factors. The code above makes use of [`EnumerationFactorGroup`](https://pgmax.readthedocs.io/en/latest/_autosummary/pgmax.fg.groups.EnumerationFactorGroup.html#pgmax.fg.groups.EnumerationFactorGroup) and [`PairwiseFactorGroup`](https://pgmax.readthedocs.io/en/latest/_autosummary/pgmax.fg.groups.PairwiseFactorGroup.html#pgmax.fg.groups.PairwiseFactorGroup), two [`FactorGroup`](https://pgmax.readthedocs.io/en/latest/_autosummary/pgmax.fg.groups.FactorGroup.html#pgmax.fg.groups.FactorGroup)s implemented in the [`pgmax.fg.groups`](https://pgmax.readthedocs.io/en/latest/_autosummary/pgmax.fg.graph.html#module-pgmax.fg.graph) module.
+# PGMax implements convenient and computationally efficient [`FactorGroup`](https://pgmax.readthedocs.io/en/latest/_autosummary/pgmax.fg.groups.FactorGroup.html#pgmax.fg.groups.FactorGroup) for representing groups of similar factors. The code above makes use of [`EnumerationFactorGroup`](https://pgmax.readthedocs.io/en/latest/_autosummary/pgmax.fg.groups.EnumerationFactorGroup.html#pgmax.fg.groups.EnumerationFactorGroup) and [`PairwiseFactorGroup`](https://pgmax.readthedocs.io/en/latest/_autosummary/pgmax.fg.groups.PairwiseFactorGroup.html#pgmax.fg.groups.PairwiseFactorGroup).
 #
-# A [`FactorGroup`](https://pgmax.readthedocs.io/en/latest/_autosummary/pgmax.fg.groups.FactorGroup.html#pgmax.fg.groups.FactorGroup) is created by calling [`fg.add_factor_group`](https://pgmax.readthedocs.io/en/latest/_autosummary/pgmax.fg.graph.FactorGraph.html#pgmax.fg.graph.FactorGraph.add_factor_group), which takes 2 arguments: `factory` which specifies the [`FactorGroup`](https://pgmax.readthedocs.io/en/latest/_autosummary/pgmax.fg.groups.FactorGroup.html#pgmax.fg.groups.FactorGroup) subclass, `variable_names_for_factors` which is a list of lists containing the name of the involved variables in the different factors, and additional arguments for the [`FactorGroup`](https://pgmax.readthedocs.io/en/latest/_autosummary/pgmax.fg.groups.FactorGroup.html#pgmax.fg.groups.FactorGroup) (e.g. `factor_configs` or `log_potential_matrix` here).
+# A [`FactorGroup`](https://pgmax.readthedocs.io/en/latest/_autosummary/pgmax.fg.groups.FactorGroup.html#pgmax.fg.groups.FactorGroup) takes as argument `variables_for_factors` which is a list of lists of the variables involved in the different factors, and additional arguments specific to each [`FactorGroup`](https://pgmax.readthedocs.io/en/latest/_autosummary/pgmax.fg.groups.FactorGroup.html#pgmax.fg.groups.FactorGroup) (e.g. `factor_configs` or `log_potential_matrix` here).
 #
-# In this example, since we construct `fg` with variables `dict(hidden=hidden_variables, visible=visible_variables)`, where `hidden_variables` and `visible_variables` are [`NDVariableArray`](https://pgmax.readthedocs.io/en/latest/_autosummary/pgmax.fg.groups.NDVariableArray.html#pgmax.fg.groups.NDVariableArray)s, we can refer to the `ii`th hidden variable as `("hidden", ii)` and the `jj`th visible variable as `("visible", jj)`. In general, PGMax implements an intuitive scheme for automatically assigning names to the variables in a [`FactorGraph`](https://pgmax.readthedocs.io/en/latest/_autosummary/pgmax.fg.graph.FactorGraph.html#pgmax.fg.graph.FactorGraph).
+# In this example, since we construct `fg` with variables `hidden_variables` and `visible_variables`, which are both [`NDVariableArray`](https://pgmax.readthedocs.io/en/latest/_autosummary/pgmax.fg.groups.NDVariableArray.html#pgmax.fg.groups.NDVariableArray)s, we can refer to the `ii`th hidden variable as `hidden_variables[ii]` and the `jj`th visible variable as `visible_variables[jj]`.
 #
-# An alternative way of creating the above factors is to add them iteratively by calling [`fg.add_factor`](https://pgmax.readthedocs.io/en/latest/_autosummary/pgmax.fg.graph.FactorGraph.html#pgmax.fg.graph.FactorGraph.add_factor) as below. This approach is not recommended as it is not computationally efficient.
+# An alternative way of creating the above factors is to add them iteratively without building the [`FactorGroup`](https://pgmax.readthedocs.io/en/latest/_autosummary/pgmax.fg.groups.FactorGroup.html#pgmax.fg.groups.FactorGroup)s as below. This approach is not recommended as it is not computationally efficient.
 # ~~~python
 # from pgmax.factors import enumeration as enumeration_factor
 # import itertools
@@ -155,30 +146,28 @@ print("Time", time.time() - start)
 # More generally, PGMax implements LBP with temperature, with `temperature=0.0` and `temperature=1.0` corresponding to the commonly used max/sum-product LBP respectively.
 #
 # Now we are ready to demonstrate PMP sampling from RBM. PMP perturbs the model with [Gumbel](https://numpy.org/doc/stable/reference/random/generated/numpy.random.gumbel.html) unary potentials, and draws a sample from the RBM as the MAP decoding from running max-product LBP on the perturbed model
+#
+# import itertools
+#
+# from tqdm import tqdm
 
 # %%
-start = time.time()
 bp = graph.BP(fg.bp_state, temperature=0.0)
-print("Time", time.time() - start)
 
 # %%
-start = time.time()
 bp_arrays = bp.init(
     evidence_updates={
         hidden_variables: np.random.gumbel(size=(bh.shape[0], 2)),
         visible_variables: np.random.gumbel(size=(bv.shape[0], 2)),
     }
 )
-print("Time", time.time() - start)
 bp_arrays = bp.run_bp(bp_arrays, num_iters=100, damping=0.5)
-print("Time", time.time() - start)
 beliefs = bp.get_beliefs(bp_arrays)
-print("Time", time.time() - start)
 
 # %% [markdown]
-# Here we use the `evidence_updates` argument of `run_bp` to perturb the model with Gumbel unary potentials. In general, `evidence_updates` can be used to incorporate evidence in the form of externally applied unary potentials in PGM inference.
+# Here we use the `evidence_updates` argument of `bp.init` to perturb the model with Gumbel unary potentials. In general, `evidence_updates` can be used to incorporate evidence in the form of externally applied unary potentials in PGM inference.
 #
-# Visualizing the MAP decoding (Figure [fig:rbm_single_digit]), we see that we have sampled an MNIST digit!
+# Visualizing the MAP decoding, we see that we have sampled an MNIST digit!
 
 # %%
 fig, ax = plt.subplots(1, 1, figsize=(10, 10))
@@ -191,23 +180,11 @@ ax.axis("off")
 # %% [markdown]
 # PGMax adopts a functional interface for implementing LBP: running LBP in PGMax starts with
 # ~~~python
-# run_bp, get_bp_state, get_beliefs = graph.BP(fg.bp_state, num_iters=NUM_ITERS, temperature=T)
+# bp = graph.BP(fg.bp_state, temperature=T)
 # ~~~
-# where `run_bp` and `get_beliefs` are pure functions with no side-effects. This design choice means that we can easily apply JAX transformations like `jit`/`vmap`/`grad`, etc., to these functions, and additionally allows PGMax to seamlessly interact with other packages in the rapidly growing JAX ecosystem (see [here](https://deepmind.com/blog/article/using-jax-to-accelerate-our-research) and [here](https://github.com/n2cholas/awesome-jax)). In what follows we demonstrate an example on applying `jax.vmap`, a convenient transformation for automatically vectorizing functions.
+# where the arguments of the `bp` are several useful functions to run LBP. In particular, `bp.init`, `bp.run_bp`, `bp.get_beliefs` are pure functions with no side-effects. This design choice means that we can easily apply JAX transformations like `jit`/`vmap`/`grad`, etc., to these functions, and additionally allows PGMax to seamlessly interact with other packages in the rapidly growing JAX ecosystem (see [here](https://deepmind.com/blog/article/using-jax-to-accelerate-our-research) and [here](https://github.com/n2cholas/awesome-jax)).
 #
-# Since we implement `run_bp`/`get_beliefs` as a pure function, we can apply `jax.vmap` to `run_bp`/`get_beliefs` to process a batch of samples/models in parallel. As an example, consider the PGMax implementation of PMP sampling from the RBM trained on MNIST images in Section [Tutorial: implementing LBP inference for RBMs with PGMax]. Instead of drawing one sample at a time
-# ~~~python
-# bp_arrays = run_bp(
-#     evidence_updates={
-#         hidden_variables: np.random.gumbel(size=(bh.shape[0], 2)),
-#         visible_variables: np.random.gumbel(size=(bv.shape[0], 2)),
-#     },
-#     damping=0.5,
-# )
-# beliefs = get_beliefs(bp_arrays)
-# map_states = graph.decode_map_states(beliefs)
-# ~~~
-# we can draw a batch of samples in parallel by transforming `run_bp`/`get_beliefs` with `jax.vmap`
+# As an example of applying `jax.vmap` to `bp.init`/`bp.run_bp`/`bp.get_beliefs` to process a batch of samples/models in parallel, instead of drawing one sample at a time as above, we can draw a batch of samples in parallel as follows:
 
 # %%
 n_samples = 10
@@ -227,7 +204,7 @@ beliefs = jax.vmap(bp.get_beliefs, in_axes=0, out_axes=0)(bp_arrays)
 map_states = graph.decode_map_states(beliefs)
 
 # %% [markdown]
-# Visualizing the MAP decodings (Figure [fig:rbm_multiple_digits]), we see that we have sampled 10 MNIST digits in parallel!
+# Visualizing the MAP decodings, we see that we have sampled 10 MNIST digits in parallel!
 
 # %%
 fig, ax = plt.subplots(2, 5, figsize=(20, 8))

--- a/examples/rbm.py
+++ b/examples/rbm.py
@@ -69,14 +69,12 @@ hidden_unaries = enumeration.EnumerationFactorGroup(
     factor_configs=np.arange(2)[:, None],
     log_potentials=np.stack([np.zeros_like(bh), bh], axis=1),
 )
-fg.add_factors(hidden_unaries)
 
 visible_unaries = enumeration.EnumerationFactorGroup(
     variables_for_factors=[[visible_variables[jj]] for jj in range(bv.shape[0])],
     factor_configs=np.arange(2)[:, None],
     log_potentials=np.stack([np.zeros_like(bv), bv], axis=1),
 )
-fg.add_factors(visible_unaries)
 
 # Add pairwise factors
 log_potential_matrix = np.zeros(W.shape + (2, 2)).reshape((-1, 2, 2))
@@ -94,7 +92,7 @@ pairwise_factors = enumeration.PairwiseFactorGroup(
 )
 print("Time", time.time() - start)
 
-fg.add_factors(pairwise_factors)
+fg.add_factors([hidden_unaries, visible_unaries, pairwise_factors])
 print("Time", time.time() - start)
 
 
@@ -107,6 +105,7 @@ print("Time", time.time() - start)
 #
 # An alternative way of creating the above factors is to add them iteratively by calling [`fg.add_factor`](https://pgmax.readthedocs.io/en/latest/_autosummary/pgmax.fg.graph.FactorGraph.html#pgmax.fg.graph.FactorGraph.add_factor) as below. This approach is not recommended as it is not computationally efficient.
 # ~~~python
+# from pgmax.factors import enumeration as enumeration_factor
 # import itertools
 # from tqdm import tqdm
 #
@@ -117,7 +116,7 @@ print("Time", time.time() - start)
 #         factor_configs=np.arange(2)[:, None],
 #         log_potentials=np.array([0, bh[ii]]),
 #     )
-#     fg.add_factors(factor=factor)
+#     fg.add_factors(factor)
 #
 # for jj in range(bv.shape[0]):
 #     factor = enumeration_factor.EnumerationFactor(
@@ -125,7 +124,7 @@ print("Time", time.time() - start)
 #         factor_configs=np.arange(2)[:, None],
 #         log_potentials=np.array([0, bv[jj]]),
 #     )
-#     fg.add_factors(factor=factor)
+#     fg.add_factors(factor)
 #
 # # Add pairwise factors
 # factor_configs = np.array(list(itertools.product(np.arange(2), repeat=2)))
@@ -136,7 +135,7 @@ print("Time", time.time() - start)
 #             factor_configs=factor_configs,
 #             log_potentials=np.array([0, 0, 0, W[ii, jj]]),
 #         )
-#         fg.add_factors(factor=factor)
+#         fg.add_factors(factor)
 # ~~~
 #
 # Once we have added the factors, we can run max-product LBP and get MAP decoding by

--- a/examples/rbm.py
+++ b/examples/rbm.py
@@ -52,7 +52,7 @@ start = time.time()
 # Initialize factor graph
 hidden_variables = vgroup.NDVariableArray(num_states=2, shape=bh.shape)
 visible_variables = vgroup.NDVariableArray(num_states=2, shape=bv.shape)
-fg = graph.FactorGraph(variables=[hidden_variables, visible_variables])
+fg = graph.FactorGraph(variable_groups=[hidden_variables, visible_variables])
 print("Time", time.time() - start)
 
 # %% [markdown]
@@ -69,14 +69,14 @@ hidden_unaries = enumeration.EnumerationFactorGroup(
     factor_configs=np.arange(2)[:, None],
     log_potentials=np.stack([np.zeros_like(bh), bh], axis=1),
 )
-fg.add_factor_group(hidden_unaries)
+fg.add_factors(hidden_unaries)
 
 visible_unaries = enumeration.EnumerationFactorGroup(
     variables_for_factors=[[visible_variables[jj]] for jj in range(bv.shape[0])],
     factor_configs=np.arange(2)[:, None],
     log_potentials=np.stack([np.zeros_like(bv), bv], axis=1),
 )
-fg.add_factor_group(visible_unaries)
+fg.add_factors(visible_unaries)
 
 # Add pairwise factors
 log_potential_matrix = np.zeros(W.shape + (2, 2)).reshape((-1, 2, 2))
@@ -90,9 +90,9 @@ pairwise_factors = enumeration.PairwiseFactorGroup(
     ],
     log_potential_matrix=log_potential_matrix,
 )
-fg.add_factor_group(pairwise_factors)
+fg.add_factors(pairwise_factors)
 
-# # %snakeviz fg.add_factor_group(factory=enumeration.PairwiseFactorGroup, variables_for_factors=v, log_potential_matrix=log_potential_matrix,)
+# # %snakeviz fg.add_factors(factory=enumeration.PairwiseFactorGroup, variables_for_factors=v, log_potential_matrix=log_potential_matrix,)
 print("Time", time.time() - start)
 
 
@@ -115,7 +115,7 @@ print("Time", time.time() - start)
 #         factor_configs=np.arange(2)[:, None],
 #         log_potentials=np.array([0, bh[ii]]),
 #     )
-#     fg.add_factor(factor)
+#     fg.add_factors(factor=factor)
 #
 # for jj in range(bv.shape[0]):
 #     factor = enumeration_factor.EnumerationFactor(
@@ -123,7 +123,7 @@ print("Time", time.time() - start)
 #         factor_configs=np.arange(2)[:, None],
 #         log_potentials=np.array([0, bv[jj]]),
 #     )
-#     fg.add_factor(factor)
+#     fg.add_factors(factor=factor)
 #
 # # Add pairwise factors
 # factor_configs = np.array(list(itertools.product(np.arange(2), repeat=2)))
@@ -134,7 +134,7 @@ print("Time", time.time() - start)
 #             factor_configs=factor_configs,
 #             log_potentials=np.array([0, 0, 0, W[ii, jj]]),
 #         )
-#         fg.add_factor(factor)
+#         fg.add_factors(factor=factor)
 # ~~~
 #
 # Once we have added the factors, we can run max-product LBP and get MAP decoding by

--- a/examples/rcn.py
+++ b/examples/rcn.py
@@ -272,7 +272,7 @@ valid_configs_list = [valid_configs(r, hps, vps) for r in range(max_perturb_radi
 
 # %%
 start = time.time()
-fg = graph.FactorGraph(variables=variables_all_models)
+fg = graph.FactorGraph(variables_all_models)
 
 # Adding rcn model edges to the pgmax factor graph.
 for idx in range(edges.shape[0]):
@@ -285,7 +285,7 @@ for idx in range(edges.shape[0]):
             factor_configs=valid_configs_list[r],
             log_potentials=np.zeros(valid_configs_list[r].shape[0]),
         )
-        fg.add_factor(factor)
+        fg.add_factors(factor=factor)
 
 end = time.time()
 print(f"Creating factors took {end-start:.3f} seconds.")

--- a/examples/rcn.py
+++ b/examples/rcn.py
@@ -211,11 +211,11 @@ M = (2 * hps + 1) * (
     2 * vps + 1
 )  # The number of pool choices for the different variables of the PGM.
 
-variables_all_models = {}
+variables_all_models = []
 for idx in range(frcs.shape[0]):
     frc = frcs[idx]
-    variables_all_models[idx] = vgroup.NDVariableArray(
-        num_states=M, shape=(frc.shape[0],)
+    variables_all_models.append(
+        vgroup.NDVariableArray(num_states=M, shape=(frc.shape[0],))
     )
 
 end = time.time()
@@ -280,7 +280,7 @@ for idx in range(edges.shape[0]):
     for e in edge:
         i1, i2, r = e
         fg.add_factor(
-            [(idx, i1), (idx, i2)],
+            [variables_all_models[idx][i1], variables_all_models[idx][i2]],
             valid_configs_list[r],
         )
 

--- a/examples/rcn.py
+++ b/examples/rcn.py
@@ -38,6 +38,7 @@ from scipy.ndimage import maximum_filter
 from scipy.signal import fftconvolve
 from sklearn.datasets import fetch_openml
 
+from pgmax.factors.enumeration import EnumerationFactor
 from pgmax.fg import graph
 from pgmax.groups import variables as vgroup
 
@@ -279,10 +280,12 @@ for idx in range(edges.shape[0]):
 
     for e in edge:
         i1, i2, r = e
-        fg.add_factor(
-            [variables_all_models[idx][i1], variables_all_models[idx][i2]],
-            valid_configs_list[r],
+        factor = EnumerationFactor(
+            variables=[variables_all_models[idx][i1], variables_all_models[idx][i2]],
+            factor_configs=valid_configs_list[r],
+            log_potentials=np.zeros(valid_configs_list[r].shape[0]),
         )
+        fg.add_factor(factor)
 
 end = time.time()
 print(f"Creating factors took {end-start:.3f} seconds.")

--- a/examples/rcn.py
+++ b/examples/rcn.py
@@ -417,8 +417,8 @@ for test_idx in range(len(test_set)):
         evidence_updates,
         map_states,
     )
-    for idx, score in enumerate(score.values()):
-        scores[test_idx, idx] = score
+    for model_idx in range(frcs.shape[0]):
+        scores[test_idx, model_idx] = score[variables_all_models[model_idx]]
     end = time.time()
     print(f"Computing scores took {end-start:.3f} seconds for image {test_idx}.")
 

--- a/pgmax/factors/enumeration.py
+++ b/pgmax/factors/enumeration.py
@@ -2,7 +2,7 @@
 
 import functools
 from dataclasses import dataclass
-from typing import Any, List, Mapping, Sequence, Tuple, Union
+from typing import List, Mapping, Sequence, Tuple, Union
 
 import jax
 import jax.numpy as jnp
@@ -157,7 +157,7 @@ class EnumerationFactor(nodes.Factor):
         factor_edges_num_states: np.ndarray,
         variables_for_factors: Sequence[List],
         factor_configs: np.ndarray,
-        vars_to_starts: Mapping[Tuple[Any, int], int],
+        vars_to_starts: Mapping[Tuple[int, int], int],
         num_factors: int,
     ) -> EnumerationWiring:
         """Compile an EnumerationWiring for an EnumerationFactor or a FactorGroup with EnumerationFactors.
@@ -183,7 +183,6 @@ class EnumerationFactor(nodes.Factor):
         Returns:
             The EnumerationWiring
         """
-        # TODO: Don't use vars_to_starts
         var_states = []
         for variables_for_factor in variables_for_factors:
             for variable in variables_for_factor:

--- a/pgmax/factors/enumeration.py
+++ b/pgmax/factors/enumeration.py
@@ -163,9 +163,8 @@ class EnumerationFactor(nodes.Factor):
         Internally calls _compile_var_states_numba and _compile_enumeration_wiring_numba for speed.
 
         Args:
-            variables_for_factors: A list of list of variables, where each innermost element is a
-                variable. Each list within the outer list is taken to contain the names of the
-                variables connected to a Factor.
+            variables_for_factors: A list of list of variables. Each list within the outer list contains the
+                variables connected to a Factor. The same variable can be connected to multiple Factors.
             factor_configs: Array of shape (num_val_configs, num_variables) containing an explicit enumeration
                 of all valid configurations.
             vars_to_starts: A dictionary that maps variables to their global starting indices

--- a/pgmax/factors/enumeration.py
+++ b/pgmax/factors/enumeration.py
@@ -1,6 +1,5 @@
 """Defines an enumeration factor"""
 
-import functools
 from dataclasses import dataclass
 from typing import List, Mapping, Sequence, Tuple, Union
 
@@ -263,7 +262,7 @@ def _compile_enumeration_wiring_numba(
                 )
 
 
-@functools.partial(jax.jit, static_argnames=("num_val_configs", "temperature"))
+# @functools.partial(jax.jit, static_argnames=("num_val_configs", "temperature"))
 def pass_enum_fac_to_var_messages(
     vtof_msgs: jnp.ndarray,
     factor_configs_edge_states: jnp.ndarray,

--- a/pgmax/factors/enumeration.py
+++ b/pgmax/factors/enumeration.py
@@ -2,7 +2,7 @@
 
 import functools
 from dataclasses import dataclass
-from typing import Mapping, Sequence, Tuple, Union
+from typing import List, Mapping, Sequence, Tuple, Union
 
 import jax
 import jax.numpy as jnp
@@ -21,7 +21,7 @@ class EnumerationWiring(nodes.Wiring):
     Args:
         factor_configs_edge_states: Array of shape (num_factor_configs, 2)
             factor_configs_edge_states[ii] contains a pair of global enumeration factor_config and global edge_state indices
-            factor_configs_edge_states[ii, 0] contains the global EnumerExpected factor_edges_num_statesationFactor config index,
+            factor_configs_edge_states[ii, 0] contains the global EnumerationFactor config index,
             factor_configs_edge_states[ii, 1] contains the corresponding global edge_state index.
             Both indices only take into account the EnumerationFactors of the FactorGraph
 
@@ -154,7 +154,7 @@ class EnumerationFactor(nodes.Factor):
 
     @staticmethod
     def compile_wiring(
-        variables_for_factors: Tuple[Tuple[int, int], ...],
+        variables_for_factors: Sequence[List],
         factor_configs: np.ndarray,
         vars_to_starts: Mapping[Tuple[int, int], int],
         num_factors: int,

--- a/pgmax/factors/enumeration.py
+++ b/pgmax/factors/enumeration.py
@@ -184,9 +184,6 @@ class EnumerationFactor(nodes.Factor):
         var_states = np.array(
             [vars_to_starts[variable] for variable in variables_for_factors]
         )
-        # num_states = np.array(
-        #     [variable.num_states for variable in variables_for_factors]
-        # )
         num_states_cumsum = np.insert(np.cumsum(factor_edges_num_states), 0, 0)
         var_states_for_edges = np.empty(shape=(num_states_cumsum[-1],), dtype=int)
         _compile_var_states_numba(var_states_for_edges, num_states_cumsum, var_states)

--- a/pgmax/factors/enumeration.py
+++ b/pgmax/factors/enumeration.py
@@ -2,7 +2,7 @@
 
 import functools
 from dataclasses import dataclass
-from typing import List, Mapping, Sequence, Tuple, Union
+from typing import Any, List, Mapping, Sequence, Tuple, Union
 
 import jax
 import jax.numpy as jnp
@@ -156,7 +156,7 @@ class EnumerationFactor(nodes.Factor):
     def compile_wiring(
         variables_for_factors: Sequence[List],
         factor_configs: np.ndarray,
-        vars_to_starts: Mapping[Tuple[int, int], int],
+        vars_to_starts: Mapping[Tuple[Any, int], int],
         num_factors: int,
     ) -> EnumerationWiring:
         """Compile an EnumerationWiring for an EnumerationFactor or a FactorGroup with EnumerationFactors.

--- a/pgmax/factors/enumeration.py
+++ b/pgmax/factors/enumeration.py
@@ -1,5 +1,6 @@
 """Defines an enumeration factor"""
 
+import functools
 from dataclasses import dataclass
 from typing import List, Mapping, Sequence, Tuple, Union
 
@@ -262,7 +263,7 @@ def _compile_enumeration_wiring_numba(
                 )
 
 
-# @functools.partial(jax.jit, static_argnames=("num_val_configs", "temperature"))
+@functools.partial(jax.jit, static_argnames=("num_val_configs", "temperature"))
 def pass_enum_fac_to_var_messages(
     vtof_msgs: jnp.ndarray,
     factor_configs_edge_states: jnp.ndarray,

--- a/pgmax/factors/logical.py
+++ b/pgmax/factors/logical.py
@@ -148,9 +148,8 @@ class LogicalFactor(nodes.Factor):
         Internally calls _compile_var_states_numba and _compile_logical_wiring_numba for speed.
 
         Args:
-            variables_for_factors: A list of list of variables, where each innermost element is a
-                variable. Each list within the outer list is taken to contain the names of the
-                variables connected to a Factor.
+            variables_for_factors: A list of list of variables. Each list within the outer list contains the
+                variables connected to a Factor. The same variable can be connected to multiple Factors.
             vars_to_starts: A dictionary that maps variables to their global starting indices
                 For an n-state variable, a global start index of m means the global indices
                 of its n variable states are m, m + 1, ..., m + n - 1

--- a/pgmax/factors/logical.py
+++ b/pgmax/factors/logical.py
@@ -86,12 +86,14 @@ class LogicalFactor(nodes.Factor):
     edge_states_offset: int = field(init=False)
 
     def __post_init__(self):
-        if len(self.variables) < 2:
+        if len(self.vars_to_num_states.keys()) < 2:
             raise ValueError(
                 "At least one parent variable and one child variable is required"
             )
 
-        if not np.all([variable.num_states == 2 for variable in self.variables]):
+        if not np.all(
+            [num_states == 2 for num_states in self.vars_to_num_states.values()]
+        ):
             raise ValueError("All variables should all be binary")
 
     @staticmethod
@@ -141,9 +143,9 @@ class LogicalFactor(nodes.Factor):
     @staticmethod
     def compile_wiring(
         factor_edges_num_states: np.ndarray,
-        variables_for_factors: Tuple[nodes.Variable, ...],
+        variables_for_factors: Tuple[int, ...],  # notsure
         factor_sizes: np.ndarray,
-        vars_to_starts: Mapping[nodes.Variable, int],
+        vars_to_starts: Mapping[int, int],
         edge_states_offset: int,
     ) -> LogicalWiring:
         """Compile a LogicalWiring for a LogicalFactor or a FactorGroup with LogicalFactors.

--- a/pgmax/factors/logical.py
+++ b/pgmax/factors/logical.py
@@ -2,7 +2,7 @@
 
 import functools
 from dataclasses import dataclass, field
-from typing import Mapping, Optional, Sequence, Tuple, Union
+from typing import List, Mapping, Optional, Sequence, Union
 
 import jax
 import jax.numpy as jnp
@@ -88,7 +88,7 @@ class LogicalFactor(nodes.Factor):
     def __post_init__(self):
         if len(self.variables) < 2:
             raise ValueError(
-                "A LogicalFactor requires at least one parent variable and one child variable "
+                "A LogicalFactor requires at least one parent variable and one child variable"
             )
 
         if not np.all([variable[1] == 2 for variable in self.variables]):
@@ -140,7 +140,7 @@ class LogicalFactor(nodes.Factor):
 
     @staticmethod
     def compile_wiring(
-        variables_for_factors: Tuple[Tuple[int, int], ...],
+        variables_for_factors: Sequence[List],
         vars_to_starts: Mapping[int, int],
         edge_states_offset: int,
     ) -> LogicalWiring:

--- a/pgmax/factors/logical.py
+++ b/pgmax/factors/logical.py
@@ -242,16 +242,6 @@ class ANDFactor(LogicalFactor):
 
 
 @nb.jit(parallel=False, cache=True, fastmath=True, nopython=True)
-def _compile_utils_numba(var_states, factor_edges_num_states, variables_for_factors):
-    idx = 0
-    for variables_for_factor in variables_for_factors:
-        for variable in variables_for_factor:
-            var_states[idx] = variable
-            factor_edges_num_states[idx] = variable[1]
-            idx += 1
-
-
-@nb.jit(parallel=False, cache=True, fastmath=True, nopython=True)
 def _compile_logical_wiring_numba(
     parents_edge_states: np.ndarray,
     children_edge_states: np.ndarray,

--- a/pgmax/factors/logical.py
+++ b/pgmax/factors/logical.py
@@ -2,7 +2,7 @@
 
 import functools
 from dataclasses import dataclass, field
-from typing import List, Mapping, Optional, Sequence, Union
+from typing import List, Mapping, Optional, Sequence, Tuple, Union
 
 import jax
 import jax.numpy as jnp
@@ -141,7 +141,7 @@ class LogicalFactor(nodes.Factor):
     @staticmethod
     def compile_wiring(
         variables_for_factors: Sequence[List],
-        vars_to_starts: Mapping[int, int],
+        vars_to_starts: Mapping[Tuple[int, int], int],
         edge_states_offset: int,
     ) -> LogicalWiring:
         """Compile a LogicalWiring for a LogicalFactor or a FactorGroup with LogicalFactors.

--- a/pgmax/factors/logical.py
+++ b/pgmax/factors/logical.py
@@ -2,7 +2,7 @@
 
 import functools
 from dataclasses import dataclass, field
-from typing import Any, List, Mapping, Optional, Sequence, Tuple, Union
+from typing import List, Mapping, Optional, Sequence, Tuple, Union
 
 import jax
 import jax.numpy as jnp
@@ -143,7 +143,7 @@ class LogicalFactor(nodes.Factor):
         factor_edges_num_states: np.ndarray,
         variables_for_factors: Sequence[List],
         factor_sizes: np.ndarray,
-        vars_to_starts: Mapping[Tuple[Any, int], int],
+        vars_to_starts: Mapping[Tuple[int, int], int],
         edge_states_offset: int,
     ) -> LogicalWiring:
         """Compile a LogicalWiring for a LogicalFactor or a FactorGroup with LogicalFactors.
@@ -164,7 +164,6 @@ class LogicalFactor(nodes.Factor):
         Returns:
             The LogicalWiring
         """
-        # TODO: Don't use vars_to_starts
         var_states = []
         for variables_for_factor in variables_for_factors:
             for variable in variables_for_factor:

--- a/pgmax/factors/logical.py
+++ b/pgmax/factors/logical.py
@@ -2,7 +2,7 @@
 
 import functools
 from dataclasses import dataclass, field
-from typing import List, Mapping, Optional, Sequence, Tuple, Union
+from typing import Any, List, Mapping, Optional, Sequence, Tuple, Union
 
 import jax
 import jax.numpy as jnp
@@ -141,7 +141,7 @@ class LogicalFactor(nodes.Factor):
     @staticmethod
     def compile_wiring(
         variables_for_factors: Sequence[List],
-        vars_to_starts: Mapping[Tuple[int, int], int],
+        vars_to_starts: Mapping[Tuple[Any, int], int],
         edge_states_offset: int,
     ) -> LogicalWiring:
         """Compile a LogicalWiring for a LogicalFactor or a FactorGroup with LogicalFactors.

--- a/pgmax/fg/graph.py
+++ b/pgmax/fg/graph.py
@@ -935,7 +935,7 @@ def BP(bp_state: BPState, temperature: float = 0.0) -> BeliefPropagation:
             ftov_msgs, edges_num_states, max_msg_size
         )
 
-        # @jax.checkpoint
+        @jax.checkpoint
         def update(msgs: jnp.ndarray, _) -> Tuple[jnp.ndarray, None]:
             # Compute new variable to factor messages by message passing
             vtof_msgs = infer.pass_var_to_fac_messages(
@@ -961,8 +961,7 @@ def BP(bp_state: BPState, temperature: float = 0.0) -> BeliefPropagation:
             # update the factor to variable messages
             delta_msgs = ftov_msgs - msgs
             msgs = msgs + (1 - damping) * delta_msgs
-            # Normalize and clip these damped, updated messages before
-            # returning them.
+            # Normalize and clip these damped, updated messages before returning them.
             msgs = infer.normalize_and_clip_msgs(msgs, edges_num_states, max_msg_size)
             return msgs, None
 

--- a/pgmax/fg/graph.py
+++ b/pgmax/fg/graph.py
@@ -65,7 +65,6 @@ class FactorGraph:
         )
 
         # See FactorGraphState docstrings for documentation on the following fields
-        # TODO: vars_to_starts does not have to be a dict
         self._vars_to_starts: Dict[Tuple[int, int], int] = {}
 
         vars_num_states_cumsum = 0

--- a/pgmax/fg/graph.py
+++ b/pgmax/fg/graph.py
@@ -323,7 +323,7 @@ class FactorGraphState:
     """
 
     variable_groups: Sequence[groups.VariableGroup]
-    vars_to_starts: Mapping[Tuple[Any, int], int]
+    vars_to_starts: Mapping[Tuple[int, int], int]
     num_var_states: int
     total_factor_num_states: int
     factor_type_to_msgs_range: OrderedDict[type, Tuple[int, int]]
@@ -460,7 +460,7 @@ class LogPotentials:
 
     def __setitem__(
         self,
-        factor_group: Any,
+        factor_group: groups.FactorGroup,
         data: Union[np.ndarray, jnp.ndarray],
     ):
         """Set the log potentials for a FactorGroup
@@ -563,7 +563,7 @@ class FToVMessages:
         """Spreading beliefs at a variable to all connected Factors
 
         Args:
-            variable: A tuple representing a variable
+            variable: Variable queried
             data: An array containing the beliefs to be spread uniformly
                 across all factors to variable messages involving this variable.
         """

--- a/pgmax/fg/graph.py
+++ b/pgmax/fg/graph.py
@@ -35,7 +35,6 @@ from jax.scipy.special import logsumexp
 from pgmax.bp import infer
 from pgmax.factors import FAC_TO_VAR_UPDATES
 from pgmax.fg import groups, nodes
-from pgmax.groups.enumeration import EnumerationFactorGroup
 from pgmax.utils import cached_property
 
 

--- a/pgmax/fg/graph.py
+++ b/pgmax/fg/graph.py
@@ -49,9 +49,6 @@ class FactorGraph:
     variable_groups: Union[groups.VariableGroup, Sequence[groups.VariableGroup]]
 
     def __post_init__(self):
-        import time
-
-        start = time.time()
         if isinstance(self.variable_groups, groups.VariableGroup):
             self.variable_groups = [self.variable_groups]
 
@@ -68,6 +65,7 @@ class FactorGraph:
         )
 
         # See FactorGraphState docstrings for documentation on the following fields
+        # TODO: vars_to_starts does not have to be a dict
         self._vars_to_starts: Dict[Tuple[int, int], int] = {}
 
         vars_num_states_cumsum = 0
@@ -82,7 +80,6 @@ class FactorGraph:
             )
             vars_num_states_cumsum += vg_num_states_cumsum[-1]
         self._num_var_states = vars_num_states_cumsum
-        print("Init", time.time() - start)
 
     def __hash__(self) -> int:
         return hash(self.factor_groups)

--- a/pgmax/fg/graph.py
+++ b/pgmax/fg/graph.py
@@ -1104,7 +1104,7 @@ def BP(bp_state: BPState, temperature: float = 0.0) -> BeliefPropagation:
 @jax.tree_util.register_pytree_node_class
 @dataclass(frozen=True, eq=False)
 class HashableDict:
-    "A convenient class"
+    "Represents a dictionnary where stored keys are the hash of the elements"
     d: Dict = field(default_factory=dict)
 
     def __post_init__(self):

--- a/pgmax/fg/graph.py
+++ b/pgmax/fg/graph.py
@@ -997,38 +997,12 @@ def BP(bp_state: BPState, temperature: float = 0.0) -> BeliefPropagation:
         Args:
             flat_beliefs: Flattened array of beliefs
             variable_groups: All the variable groups in the FactorGraph.
-
-        Raises:
-            ValueError: If
-                (1) flat_beliefs is not one dimensional
-                (2) flat_beliefs is not of the right shape
         """
-
-        if flat_beliefs.ndim != 1:
-            raise ValueError(
-                f"Can only unflatten 1D array. Got a {flat_beliefs.ndim}D array."
-            )
-
-        num_variables = 0
-        num_variable_states = 0
-        for variable_group in variable_groups:
-            variables = variable_group.variables
-            num_variables += len(variables)
-            num_variable_states += sum([variable[1] for variable in variables])
-
-        if flat_beliefs.shape[0] == num_variables:
-            use_num_states = False
-        elif flat_beliefs.shape[0] == num_variable_states:
-            use_num_states = True
-
         beliefs = {}
         start = 0
         for variable_group in variable_groups:
             variables = variable_group.variables
-            if not use_num_states:
-                length = len(variables)
-            else:
-                length = sum([variable[1] for variable in variables])
+            length = sum([variable[1] for variable in variables])
 
             beliefs[variable_group] = variable_group.unflatten(
                 flat_beliefs[start : start + length]

--- a/pgmax/fg/graph.py
+++ b/pgmax/fg/graph.py
@@ -68,9 +68,8 @@ class FactorGraph:
         )
 
         # See FactorGraphState docstrings for documentation on the following fields
-        self._vars_to_starts: OrderedDict[
-            Tuple[int, int], int
-        ] = collections.OrderedDict()
+        self._vars_to_starts: Dict[Tuple[int, int], int] = {}
+
         vars_num_states_cumsum = 0
         for variable_group in self.variable_groups:
             vg_num_states = variable_group.num_states.flatten()
@@ -159,7 +158,7 @@ class FactorGraph:
                     factor_group
                 ] = factor_num_configs_cumsum
 
-                factor_num_states_cumsum += factor_group.total_num_states
+                factor_num_states_cumsum += factor_group.factor_edges_num_states.sum()
                 factor_num_configs_cumsum += (
                     factor_group.factor_group_log_potentials.shape[0]
                 )

--- a/pgmax/fg/graph.py
+++ b/pgmax/fg/graph.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from this import d
-
 """A module containing the core class to specify a Factor Graph."""
 
 import collections
@@ -102,9 +100,7 @@ class FactorGraph:
         print("2", time.time() - start)
 
         # Used to add FactorGroups
-        # TODO: dict is faster
-        aa = zip(vars_names, vars_num_states)
-        print("3", time.time() - start)
+        # TODO: move to dict, which is faster
         self._vars_to_num_states: OrderedDict[int, int] = collections.OrderedDict(
             zip(vars_names, vars_num_states)
         )
@@ -434,12 +430,14 @@ class FactorGraphState:
     wiring: OrderedDict[type, nodes.Wiring]
 
     def __post_init__(self):
-        for field in self.__dataclass_fields__:
-            if isinstance(getattr(self, field), np.ndarray):
-                getattr(self, field).flags.writeable = False
+        for this_field in self.__dataclass_fields__:
+            if isinstance(getattr(self, this_field), np.ndarray):
+                getattr(self, this_field).flags.writeable = False
 
-            if isinstance(getattr(self, field), Mapping):
-                object.__setattr__(self, field, MappingProxyType(getattr(self, field)))
+            if isinstance(getattr(self, this_field), Mapping):
+                object.__setattr__(
+                    self, this_field, MappingProxyType(getattr(self, this_field))
+                )
 
 
 @dataclass(frozen=True, eq=False)
@@ -848,9 +846,9 @@ class BPArrays:
     evidence: Union[np.ndarray, jnp.ndarray]
 
     def __post_init__(self):
-        for field in self.__dataclass_fields__:
-            if isinstance(getattr(self, field), np.ndarray):
-                getattr(self, field).flags.writeable = False
+        for this_field in self.__dataclass_fields__:
+            if isinstance(getattr(self, this_field), np.ndarray):
+                getattr(self, this_field).flags.writeable = False
 
     def tree_flatten(self):
         return jax.tree_util.tree_flatten(asdict(self))

--- a/pgmax/fg/graph.py
+++ b/pgmax/fg/graph.py
@@ -460,7 +460,7 @@ class LogPotentials:
                 start : start + factor_group.factor_group_log_potentials.shape[0]
             ]
         else:
-            raise ValueError("Invalid FactorGroup for log potentials updates.")
+            raise ValueError("Invalid FactorGroup queried to access log potentials.")
         return log_potentials
 
     def __setitem__(

--- a/pgmax/fg/groups.py
+++ b/pgmax/fg/groups.py
@@ -45,12 +45,11 @@ class VariableGroup:
 
     @cached_property
     def variables(self) -> Tuple[Any, int]:
-        """Function that returns the list of variables. Each variable is represented
-        by a tuple of the variable name (which can be a hash or a string) and its
-        number of states.
+        """Function that returns the list of all variables in the VariableGroup.
+        Each variable is represented by a tuple of the form (variable name, number of states)
 
         Returns:
-           List of variables in the VariableGroup
+            List of variables in the VariableGroup
         """
         raise NotImplementedError(
             "Please subclass the VariableGroup class and override this method"
@@ -88,9 +87,8 @@ class FactorGroup:
     """Class to represent a group of Factors.
 
     Args:
-        variables_for_factors: A list of list of variables, where each innermost element is a
-            variable. Each list within the outer list is taken to contain the names of the
-            variables connected to a Factor.
+        variables_for_factors: A list of list of variables. Each list within the outer list contains the
+            variables connected to a Factor. The same variable can be connected to multiple Factors.
         factor_configs: Optional array containing an explicit enumeration of all valid configurations
         log_potentials: Array of log potentials.
 
@@ -142,8 +140,12 @@ class FactorGroup:
 
     @cached_property
     def total_num_states(self) -> int:
-        """TODO"""
-        # TODO: this could be returned by the wiring
+        """Function to return the total number of states for all the variables involved in all the Factors
+
+        Returns:
+            Total number of variable states in the FactorGroup
+        """
+        # TODO: this could be returned by the wiring to loop over variables_for_factors only once
         return sum(
             [
                 variable[1]
@@ -293,18 +295,3 @@ class SingleFactorGroup(FactorGroup):
         raise NotImplementedError(
             "SingleFactorGroup does not support vectorized factor operations."
         )
-
-
-# def get_ndvariable_names_for_factor_groups(
-#     arrays: List[Any]
-
-# ):
-#     "Util function"
-
-# import numba as nb
-# @nb.jit(parallel=False, cache=True, fastmath=True, nopython=True)
-# def run_numba(h, v, f):
-#     for h_idx in nb.prange(h.shape[0]):
-#         for v_idx in nb.prange(v.shape[0]):
-#             f[h_idx * v.shape[0] + v_idx, 0] = h[h_idx]
-#             f[h_idx * v.shape[0] + v_idx, 1] = v[v_idx]

--- a/pgmax/fg/groups.py
+++ b/pgmax/fg/groups.py
@@ -200,7 +200,6 @@ class FactorGroup:
         """
         factor_edges_num_states = np.empty(shape=(self.factor_sizes.sum(),), dtype=int)
 
-        # TODO: create variables_for_factors as an array and move this to numba
         idx = 0
         for variables_for_factor in self.variables_for_factors:
             for variable in variables_for_factor:

--- a/pgmax/fg/groups.py
+++ b/pgmax/fg/groups.py
@@ -271,7 +271,7 @@ class FactorGroup:
             "Please subclass the FactorGroup class and override this method"
         )
 
-    def compile_wiring(self, vars_to_starts: Mapping[Tuple[Any, int], int]) -> Any:
+    def compile_wiring(self, vars_to_starts: Mapping[Tuple[int, int], int]) -> Any:
         """Compile an efficient wiring for the FactorGroup.
 
         Args:

--- a/pgmax/fg/groups.py
+++ b/pgmax/fg/groups.py
@@ -23,8 +23,6 @@ import numpy as np
 import pgmax.fg.nodes as nodes
 from pgmax.utils import cached_property
 
-MAX_SIZE = 1e10
-
 
 @total_ordering
 @dataclass(frozen=True, eq=False)

--- a/pgmax/fg/groups.py
+++ b/pgmax/fg/groups.py
@@ -41,12 +41,12 @@ class VariableGroup:
     def __post_init__(self):
         # Only compute the hash once, which is guaranteed to be an int64
         this_id = id(self) % 2**32
-        this_hash = this_id * int(MAX_SIZE)
-        assert this_hash < 2**63
-        object.__setattr__(self, "this_hash", this_hash)
+        _hash = this_id * int(MAX_SIZE)
+        assert _hash < 2**63
+        object.__setattr__(self, "_hash", _hash)
 
     def __hash__(self):
-        return self.this_hash
+        return self._hash
 
     def __eq__(self, other):
         return hash(self) == hash(other)

--- a/pgmax/fg/groups.py
+++ b/pgmax/fg/groups.py
@@ -101,6 +101,7 @@ class VariableGroup:
         )
 
 
+@total_ordering
 @dataclass(frozen=True, eq=False)
 class FactorGroup:
     """Class to represent a group of Factors.
@@ -126,6 +127,15 @@ class FactorGroup:
     def __post_init__(self):
         if len(self.variables_for_factors) == 0:
             raise ValueError("Cannot create a FactorGroup with no Factor.")
+
+    def __hash__(self):
+        return id(self)
+
+    def __eq__(self, other):
+        return hash(self) == hash(other)
+
+    def __lt__(self, other):
+        return hash(self) < hash(other)
 
     def __getitem__(self, variables: Sequence[Tuple[int, int]]) -> Any:
         """Function to query individual factors in the factor group

--- a/pgmax/fg/groups.py
+++ b/pgmax/fg/groups.py
@@ -31,27 +31,26 @@ class VariableGroup:
     """
 
     def __getitem__(self, val):
-        """Given a name, retrieve the associated Variable.
+        """Given a variable name, retrieve the associated Variable.
 
         Args:
             val: a single name corresponding to a single variable, or a list of such names
 
         Returns:
             A single variable if the name is not a list. A list of variables if name is a list
-
-        Raises:
-            ValueError: if the name is not found in the group
         """
         raise NotImplementedError(
             "Please subclass the VariableGroup class and override this method"
         )
 
     @cached_property
-    def variables_names(self) -> Any:
-        """Function that generates a dictionary mapping names to variables.
+    def variables(self) -> Tuple[Any, int]:
+        """Function that returns the list of variables. Each variable is represented
+        by a tuple of the variable name (which can be a hash or a string) and its
+        number of states.
 
         Returns:
-            a dictionary mapping all possible names to different variables.
+           List of variables in the VariableGroup
         """
         raise NotImplementedError(
             "Please subclass the VariableGroup class and override this method"
@@ -205,7 +204,7 @@ class FactorGroup:
             "Please subclass the FactorGroup class and override this method"
         )
 
-    def compile_wiring(self, vars_to_starts: Mapping[int, int]) -> Any:
+    def compile_wiring(self, vars_to_starts: Mapping[Tuple[int, int], int]) -> Any:
         """Compile an efficient wiring for the FactorGroup.
 
         Args:

--- a/pgmax/fg/groups.py
+++ b/pgmax/fg/groups.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from functools import total_ordering
 from typing import (
     Any,
+    Collection,
     FrozenSet,
     List,
     Mapping,
@@ -21,7 +22,7 @@ import numpy as np
 import pgmax.fg.nodes as nodes
 from pgmax.utils import cached_property
 
-MAX_SIZE = 1e16
+MAX_SIZE = 1e10
 
 
 @total_ordering
@@ -40,7 +41,7 @@ class VariableGroup:
     def __lt__(self, other):
         return hash(self) < hash(other)
 
-    def __getitem__(self, val):
+    def __getitem__(self, val: Any) -> Union[Tuple[Any, int], List[Tuple[Any, int]]]:
         """Given a variable name, index, or a group of variable indices, retrieve the associated variable(s).
         Each variable is returned via a tuple of the form (variable hash/name, number of states)
 
@@ -129,7 +130,7 @@ class FactorGroup:
     def __lt__(self, other):
         return hash(self) < hash(other)
 
-    def __getitem__(self, variables: Sequence[Tuple[int, int]]) -> Any:
+    def __getitem__(self, variables: Union[Sequence, Collection]) -> Any:
         """Function to query individual factors in the factor group
 
         Args:
@@ -228,7 +229,7 @@ class FactorGroup:
             "Please subclass the FactorGroup class and override this method"
         )
 
-    def compile_wiring(self, vars_to_starts: Mapping[Tuple[int, int], int]) -> Any:
+    def compile_wiring(self, vars_to_starts: Mapping[Tuple[Any, int], int]) -> Any:
         """Compile an efficient wiring for the FactorGroup.
 
         Args:

--- a/pgmax/fg/groups.py
+++ b/pgmax/fg/groups.py
@@ -143,6 +143,7 @@ class FactorGroup:
     @cached_property
     def total_num_states(self) -> int:
         """TODO"""
+        # TODO: this could be returned by the wiring
         return sum(
             [
                 variable[1]

--- a/pgmax/fg/groups.py
+++ b/pgmax/fg/groups.py
@@ -311,3 +311,18 @@ class SingleFactorGroup(FactorGroup):
         raise NotImplementedError(
             "SingleFactorGroup does not support vectorized factor operations."
         )
+
+
+# def get_ndvariable_names_for_factor_groups(
+#     arrays: List[Any]
+
+# ):
+#     "Util function"
+
+# import numba as nb
+# @nb.jit(parallel=False, cache=True, fastmath=True, nopython=True)
+# def run_numba(h, v, f):
+#     for h_idx in nb.prange(h.shape[0]):
+#         for v_idx in nb.prange(v.shape[0]):
+#             f[h_idx * v.shape[0] + v_idx, 0] = h[h_idx]
+#             f[h_idx * v.shape[0] + v_idx, 1] = v[v_idx]

--- a/pgmax/fg/groups.py
+++ b/pgmax/fg/groups.py
@@ -33,34 +33,13 @@ class VariableGroup:
     All variables in the group are assumed to have the same size. Additionally, the
     variables are indexed by a variable name, and can be retrieved by direct indexing (even indexing
     a sequence of variable names) of the VariableGroup.
-
-    Attributes:
-        _names_to_variables: A private, immutable mapping from variable names to variables
     """
 
-    _names_to_variables: Mapping[Hashable, nodes.Variable] = field(init=False)
-
-    def __post_init__(self) -> None:
-        """Initialize a private, immutable mapping from variable names to variables."""
-        object.__setattr__(
-            self,
-            "_names_to_variables",
-            MappingProxyType(self._get_names_to_variables()),
-        )
-
-    @typing.overload
-    def __getitem__(self, name: Hashable) -> nodes.Variable:
-        """This function is a typing overload and is overwritten by the implemented __getitem__"""
-
-    @typing.overload
-    def __getitem__(self, name: List) -> List[nodes.Variable]:
-        """This function is a typing overload and is overwritten by the implemented __getitem__"""
-
-    def __getitem__(self, name):
+    def __getitem__(self, val):
         """Given a name, retrieve the associated Variable.
 
         Args:
-            name: a single name corresponding to a single variable, or a list of such names
+            val: a single name corresponding to a single variable, or a list of such names
 
         Returns:
             A single variable if the name is not a list. A list of variables if name is a list
@@ -68,28 +47,12 @@ class VariableGroup:
         Raises:
             ValueError: if the name is not found in the group
         """
-        if isinstance(name, List):
-            names_list = name
-        else:
-            names_list = [name]
+        raise NotImplementedError(
+            "Please subclass the VariableGroup class and override this method"
+        )
 
-        vars_list = []
-        for curr_name in names_list:
-            var = self._names_to_variables.get(curr_name)
-            if var is None:
-                raise ValueError(
-                    f"The name {curr_name} is not present in the VariableGroup {type(self)}; please ensure "
-                    "it's been added to the VariableGroup before trying to query it."
-                )
-
-            vars_list.append(var)
-
-        if isinstance(name, List):
-            return vars_list
-        else:
-            return vars_list[0]
-
-    def _get_names_to_variables(self) -> OrderedDict[Any, nodes.Variable]:
+    @cached_property
+    def variables_names(self) -> Any:
         """Function that generates a dictionary mapping names to variables.
 
         Returns:
@@ -98,31 +61,6 @@ class VariableGroup:
         raise NotImplementedError(
             "Please subclass the VariableGroup class and override this method"
         )
-
-    @cached_property
-    def names(self) -> Tuple[Any, ...]:
-        """Function to return a tuple of all names in the group.
-
-        Returns:
-            tuple of all names that are part of this VariableGroup
-        """
-        return tuple(self._names_to_variables.keys())
-
-    @cached_property
-    def variables(self) -> Tuple[nodes.Variable, ...]:
-        """Function to return a tuple of all variables in the group.
-
-        Returns:
-            tuple of all variable that are part of this VariableGroup
-        """
-        return tuple(self._names_to_variables.values())
-
-    @cached_property
-    def container_names(self) -> Tuple:
-        """Placeholder function. Returns a tuple containing None for all variable groups
-        other than a composite variable group
-        """
-        return (None,)
 
     def flatten(self, data: Any) -> jnp.ndarray:
         """Function that turns meaningful structured data into a flat data array for internal use.
@@ -152,219 +90,20 @@ class VariableGroup:
 
 
 @dataclass(frozen=True, eq=False)
-class CompositeVariableGroup(VariableGroup):
-    """A class to encapsulate a collection of instantiated VariableGroups.
-
-    This class enables users to wrap various different VariableGroups and then index
-    them in a straightforward manner. To index into a CompositeVariableGroup, simply
-    provide the name of the VariableGroup within this CompositeVariableGroup followed
-    by the name to be indexed within the VariableGroup.
-
-    Args:
-        variable_group_container: A container containing multiple variable groups.
-            Supported containers include mapping and sequence.
-            For a mapping, the names of the mapping are used to index the variable groups.
-            For a sequence, the indices of the sequence are used to index the variable groups.
-
-    Attributes:
-        _names_to_variables: A private, immutable mapping from names to variables
-    """
-
-    variable_group_container: Union[
-        Mapping[Hashable, VariableGroup], Sequence[VariableGroup]
-    ]
-
-    def __post_init__(self):
-        object.__setattr__(
-            self,
-            "_names_to_variables",
-            MappingProxyType(self._get_names_to_variables()),
-        )
-
-    @typing.overload
-    def __getitem__(self, name: Hashable) -> nodes.Variable:
-        """This function is a typing overload and is overwritten by the implemented __getitem__"""
-
-    @typing.overload
-    def __getitem__(self, name: List) -> List[nodes.Variable]:
-        """This function is a typing overload and is overwritten by the implemented __getitem__"""
-
-    def __getitem__(self, name):
-        """Given a name, retrieve the associated Variable from the associated VariableGroup.
-
-        Args:
-            name: a single name corresponding to a single Variable within a VariableGroup, or a list
-                of such names
-
-        Returns:
-            A single variable if the name is not a list. A list of variables if name is a list
-
-        Raises:
-            ValueError: if the name does not have the right format (tuples with at least two elements).
-        """
-        if isinstance(name, List):
-            names_list = name
-        else:
-            names_list = [name]
-
-        vars_list = []
-        for curr_name in names_list:
-            if len(curr_name) < 2:
-                raise ValueError(
-                    "The name needs to have at least 2 elements to index from a composite variable group."
-                )
-
-            variable_group = self.variable_group_container[curr_name[0]]
-            if len(curr_name) == 2:
-                vars_list.append(variable_group[curr_name[1]])
-            else:
-                vars_list.append(variable_group[curr_name[1:]])
-
-        if isinstance(name, List):
-            return vars_list
-        else:
-            return vars_list[0]
-
-    def _get_names_to_variables(self) -> OrderedDict[Hashable, nodes.Variable]:
-        """Function that generates a dictionary mapping names to variables.
-
-        Returns:
-            a dictionary mapping all possible names to different variables.
-        """
-        names_to_variables: OrderedDict[
-            Hashable, nodes.Variable
-        ] = collections.OrderedDict()
-        for container_name in self.container_names:
-            for variable_group_name in self.variable_group_container[
-                container_name
-            ].names:
-                if isinstance(variable_group_name, tuple):
-                    names_to_variables[
-                        (container_name,) + variable_group_name
-                    ] = self.variable_group_container[container_name][
-                        variable_group_name
-                    ]
-                else:
-                    names_to_variables[
-                        (container_name, variable_group_name)
-                    ] = self.variable_group_container[container_name][
-                        variable_group_name
-                    ]
-
-        return names_to_variables
-
-    def flatten(self, data: Union[Mapping, Sequence]) -> jnp.ndarray:
-        """Function that turns meaningful structured data into a flat data array for internal use.
-
-        Args:
-            data: Meaningful structured data.
-                The structure of data should match self.variable_group_container.
-
-        Returns:
-            A flat jnp.array for internal use
-        """
-        flat_data = jnp.concatenate(
-            [
-                self.variable_group_container[name].flatten(data[name])
-                for name in self.container_names
-            ]
-        )
-        return flat_data
-
-    def unflatten(
-        self, flat_data: Union[np.ndarray, jnp.ndarray]
-    ) -> Union[Mapping, Sequence]:
-        """Function that recovers meaningful structured data from internal flat data array
-
-        Args:
-            flat_data: Internal flat data array.
-
-        Returns:
-            Meaningful structured data, with structure matching that of self.variable_group_container.
-
-        Raises:
-            ValueError if:
-                (1) flat_data is not a 1D array
-                (2) flat_data is not of the right shape
-        """
-        if flat_data.ndim != 1:
-            raise ValueError(
-                f"Can only unflatten 1D array. Got a {flat_data.ndim}D array."
-            )
-
-        num_variables = 0
-        num_variable_states = 0
-        for name in self.container_names:
-            variable_group = self.variable_group_container[name]
-            num_variables += len(variable_group.variables)
-            num_variable_states += (
-                len(variable_group.variables) * variable_group.variables[0].num_states
-            )
-
-        if flat_data.shape[0] == num_variables:
-            use_num_states = False
-        elif flat_data.shape[0] == num_variable_states:
-            use_num_states = True
-        else:
-            raise ValueError(
-                f"flat_data should be either of shape (num_variables(={len(self.variables)}),), "
-                f"or (num_variable_states(={num_variable_states}),). "
-                f"Got {flat_data.shape}"
-            )
-
-        data: List[np.ndarray] = []
-        start = 0
-        for name in self.container_names:
-            variable_group = self.variable_group_container[name]
-            length = len(variable_group.variables)
-            if use_num_states:
-                length *= variable_group.variables[0].num_states
-
-            data.append(variable_group.unflatten(flat_data[start : start + length]))
-            start += length
-        if isinstance(self.variable_group_container, Mapping):
-            return dict(
-                [(name, data[kk]) for kk, name in enumerate(self.container_names)]
-            )
-        else:
-            return data
-
-    @cached_property
-    def container_names(self) -> Tuple:
-        """Function to get names referring to the variable groups within this
-        CompositeVariableGroup.
-
-        Returns:
-            a tuple of the names referring to the variable groups within this
-            CompositeVariableGroup.
-        """
-        if isinstance(self.variable_group_container, Mapping):
-            container_names = tuple(self.variable_group_container.keys())
-        else:
-            container_names = tuple(range(len(self.variable_group_container)))
-
-        return container_names
-
-
-@dataclass(frozen=True, eq=False)
 class FactorGroup:
     """Class to represent a group of Factors.
 
     Args:
-        variable_group: either a VariableGroup or - if the elements of more than one VariableGroup
-            are connected to this FactorGroup - then a CompositeVariableGroup. This holds
-            all the variables that are connected to this FactorGroup
+        vars_to_num_states: TODO
         variable_names_for_factors: A list of list of variable names, where each innermost element is the
-            name of a variable in variable_group. Each list within the outer list is taken to contain
-            the names of the variables connected to a Factor.
+            name of a variable. Each list within the outer list is taken to contain the names of the
+            variables connected to a Factor.
         factor_configs: Optional array containing an explicit enumeration of all valid configurations
         log_potentials: Array of log potentials.
 
     Attributes:
         factor_type: Factor type shared by all the Factors in the FactorGroup.
         factor_sizes: Array of the different factor sizes.
-        variables_for_factors: Tuple concatenating the variables connected to each factor in the FactorGroup.
-            Each variable will appear once for each Factor it connects to.
         factor_edges_num_states: Array concatenating the number of states for the variables connected to each Factor of
             the FactorGroup. Each variable will appear once for each Factor it connects to.
 
@@ -372,36 +111,39 @@ class FactorGroup:
         ValueError: if the FactorGroup does not contain a Factor
     """
 
-    variable_group: Union[CompositeVariableGroup, VariableGroup]
+    vars_to_num_states: Mapping[int, int]
     variable_names_for_factors: Sequence[List]
     factor_configs: np.ndarray = field(init=False)
     log_potentials: np.ndarray = field(init=False, default=np.empty((0,)))
     factor_type: Type = field(init=False)
     factor_sizes: np.ndarray = field(init=False)
-    variables_for_factors: Tuple[nodes.Variable, ...] = field(init=False)
+    variables_for_factors: Tuple[Tuple[int], ...] = field(init=False)
     factor_edges_num_states: np.ndarray = field(init=False)
 
     def __post_init__(self):
         if len(self.variable_names_for_factors) == 0:
             raise ValueError("Do not add a factor group with no factors.")
 
+        # Note: variable_names_for_factors contains the HASHes
+        # Note: this can probably be sped up by numba
         factor_sizes = []
-        variables_for_factors = []
+        flat_var_names_for_factors = []
         factor_edges_num_states = []
         for variable_names_for_factor in self.variable_names_for_factors:
             for variable_name in variable_names_for_factor:
-                variable = self.variable_group._names_to_variables[variable_name]
-                variables_for_factors.append(variable)
-                factor_edges_num_states.append(variable.num_states)
+                factor_edges_num_states.append(self.vars_to_num_states[variable_name])
+                flat_var_names_for_factors.append(variable_name)
             factor_sizes.append(len(variable_names_for_factor))
 
         object.__setattr__(self, "factor_sizes", np.array(factor_sizes))
-        object.__setattr__(self, "variables_for_factors", tuple(variables_for_factors))
+        object.__setattr__(
+            self, "variables_for_factors", np.array(flat_var_names_for_factors)
+        )
         object.__setattr__(
             self, "factor_edges_num_states", np.array(factor_edges_num_states)
         )
 
-    def __getitem__(self, variables: Union[Sequence, Collection]) -> Any:
+    def __getitem__(self, variables: Sequence[int]) -> Any:
         """Function to query individual factors in the factor group
 
         Args:
@@ -419,7 +161,6 @@ class FactorGroup:
             raise ValueError(
                 f"The queried factor connected to the set of variables {variables} is not present in the factor group."
             )
-
         return self._variables_to_factors[variables]
 
     @cached_property
@@ -485,7 +226,7 @@ class FactorGroup:
             "Please subclass the FactorGroup class and override this method"
         )
 
-    def compile_wiring(self, vars_to_starts: Mapping[nodes.Variable, int]) -> Any:
+    def compile_wiring(self, vars_to_starts: Mapping[int, int]) -> Any:
         """Compile an efficient wiring for the FactorGroup.
 
         Args:

--- a/pgmax/fg/groups.py
+++ b/pgmax/fg/groups.py
@@ -29,14 +29,14 @@ MAX_SIZE = 1e9
 @dataclass(frozen=True, eq=False)
 class VariableGroup:
     """Class to represent a group of variables.
-    Each variable is represented via a tuple of the form (variable hash/name, number of states)
+    Each variable is represented via a tuple of the form (variable hash, variable num_states)
 
     Arguments:
         num_states: An integer or an array specifying the number of states of the variables
             in this VariableGroup
     """
 
-    num_states: Union[int, np.ndarray] = field(init=False)
+    num_states: Union[int, np.ndarray]
 
     def __post_init__(self):
         # Only compute the hash once, which is guaranteed to be an int64
@@ -56,7 +56,7 @@ class VariableGroup:
 
     def __getitem__(self, val: Any) -> Union[Tuple[int, int], List[Tuple[int, int]]]:
         """Given a variable name, index, or a group of variable indices, retrieve the associated variable(s).
-        Each variable is returned via a tuple of the form (variable hash, number of states)
+        Each variable is returned via a tuple of the form (variable hash, variable num_states)
 
         Args:
             val: a variable index, slice, or name
@@ -82,7 +82,7 @@ class VariableGroup:
     @cached_property
     def variables(self) -> List[Tuple[int, int]]:
         """Function that returns the list of all variables in the VariableGroup.
-        Each variable is represented by a tuple of the form (variable hash, number of states)
+        Each variable is represented by a tuple of the form (variable hash, variable num_states)
 
         Returns:
             List of variables in the VariableGroup

--- a/pgmax/fg/groups.py
+++ b/pgmax/fg/groups.py
@@ -23,6 +23,8 @@ import numpy as np
 import pgmax.fg.nodes as nodes
 from pgmax.utils import cached_property
 
+MAX_SIZE = 1e9
+
 
 @total_ordering
 @dataclass(frozen=True, eq=False)
@@ -33,6 +35,13 @@ class VariableGroup:
     Attributes:
         this_hash: Hash of the VariableGroup
     """
+
+    def __post_init__(self):
+        # Only compute the hash once, which is guaranteed to be an int64
+        this_id = id(self) % 2**32
+        this_hash = this_id * int(MAX_SIZE)
+        assert this_hash < 2**63
+        object.__setattr__(self, "this_hash", this_hash)
 
     def __hash__(self):
         return self.this_hash
@@ -328,9 +337,7 @@ class SingleFactorGroup(FactorGroup):
         )
 
 
-nb.jit(parallel=False, cache=True, fastmath=True, nopython=False)
-
-
+# @nb.jit(parallel=False, cache=True, fastmath=True)
 def _compile_edges_num_states_numba(factor_edges_num_states, variables_for_factors):
     idx = 0
     for variables_for_factor in variables_for_factors:

--- a/pgmax/fg/groups.py
+++ b/pgmax/fg/groups.py
@@ -27,10 +27,10 @@ from pgmax.utils import cached_property
 @dataclass(frozen=True, eq=False)
 class VariableGroup:
     """Class to represent a group of variables.
+    Each variable is represented via a tuple of the form (variable hash/name, number of states)
 
-    All variables in the group are assumed to have the same size. Additionally, the
-    variables are indexed by a variable name, and can be retrieved by direct indexing (even indexing
-    a sequence of variable names) of the VariableGroup.
+    Attributes:
+        random_hash: Hash of the VariableGroup
     """
 
     def __post_init__(self):

--- a/pgmax/fg/groups.py
+++ b/pgmax/fg/groups.py
@@ -123,7 +123,7 @@ class FactorGroup:
 
     def __post_init__(self):
         if len(self.variables_for_factors) == 0:
-            raise ValueError("Do not add a factor group with no factors.")
+            raise ValueError("Cannot create a FactorGroup with no Factor.")
 
     def __getitem__(self, variables: Sequence[Tuple[int, int]]) -> Any:
         """Function to query individual factors in the factor group
@@ -276,6 +276,10 @@ class SingleFactorGroup(FactorGroup):
         for key in compile_wiring_arguments:
             if not hasattr(self, key):
                 object.__setattr__(self, key, getattr(self.factor, key))
+
+        object.__setattr__(
+            self, "log_potentials", getattr(self.factor, "log_potentials")
+        )
 
     def _get_variables_to_factors(
         self,

--- a/pgmax/fg/groups.py
+++ b/pgmax/fg/groups.py
@@ -34,6 +34,8 @@ class VariableGroup:
     """
 
     def __post_init__(self):
+        # Overwite default hash to have larger differences
+        random.seed(id(self))
         random_hash = random.randint(0, 2**63)
         object.__setattr__(self, "random_hash", random_hash)
 

--- a/pgmax/fg/groups.py
+++ b/pgmax/fg/groups.py
@@ -1,7 +1,6 @@
 """A module containing the base classes for variable and factor groups in a Factor Graph."""
 
 import inspect
-import random
 from dataclasses import dataclass, field
 from functools import total_ordering
 from typing import (
@@ -22,25 +21,18 @@ import numpy as np
 import pgmax.fg.nodes as nodes
 from pgmax.utils import cached_property
 
+MAX_SIZE = 1e16
+
 
 @total_ordering
 @dataclass(frozen=True, eq=False)
 class VariableGroup:
     """Class to represent a group of variables.
     Each variable is represented via a tuple of the form (variable hash/name, number of states)
-
-    Attributes:
-        random_hash: Hash of the VariableGroup
     """
 
-    def __post_init__(self):
-        # Overwite default hash to have larger differences
-        random.seed(id(self))
-        random_hash = random.randint(0, 2**63)
-        object.__setattr__(self, "random_hash", random_hash)
-
     def __hash__(self):
-        return self.random_hash
+        return id(self) * int(MAX_SIZE)
 
     def __eq__(self, other):
         return hash(self) == hash(other)
@@ -63,7 +55,7 @@ class VariableGroup:
         )
 
     @cached_property
-    def variables(self) -> Tuple[Any, int]:
+    def variables(self) -> List[Tuple]:
         """Function that returns the list of all variables in the VariableGroup.
         Each variable is represented by a tuple of the form (variable hash/name, number of states)
 

--- a/pgmax/fg/groups.py
+++ b/pgmax/fg/groups.py
@@ -1,15 +1,10 @@
 """A module containing the base classes for variable and factor groups in a Factor Graph."""
 
-import collections
 import inspect
-import typing
 from dataclasses import dataclass, field
-from types import MappingProxyType
 from typing import (
     Any,
-    Collection,
     FrozenSet,
-    Hashable,
     List,
     Mapping,
     OrderedDict,

--- a/pgmax/fg/nodes.py
+++ b/pgmax/fg/nodes.py
@@ -1,7 +1,7 @@
 """A module containing classes that specify the basic components of a Factor Graph."""
 
 from dataclasses import asdict, dataclass
-from typing import Any, List, Sequence, Tuple, Union
+from typing import List, Sequence, Tuple, Union
 
 import jax
 import jax.numpy as jnp
@@ -48,7 +48,7 @@ class Factor:
         NotImplementedError: If compile_wiring is not implemented
     """
 
-    variables: List[Tuple[Any, int]]
+    variables: List[Tuple[int, int]]
     log_potentials: np.ndarray
 
     def __post_init__(self):

--- a/pgmax/fg/nodes.py
+++ b/pgmax/fg/nodes.py
@@ -41,8 +41,8 @@ class Factor:
     """A factor
 
     Args:
-        variables: List of variables in the factors. Each variable is represented
-            by a tuple containing the variable hash and number of states.
+        variables: List of variables connected by the Factor.
+            Each variable is represented by a tuple of the form (variable hash/name, number of states)
 
     Raises:
         NotImplementedError: If compile_wiring is not implemented
@@ -56,16 +56,6 @@ class Factor:
             raise NotImplementedError(
                 "Please implement compile_wiring in for your factor"
             )
-
-    # @utils.cached_property
-    # def edges_num_states(self) -> np.ndarray:
-    #     """Number of states for the variables connected to each edge
-
-    #     Returns:
-    #         Array of shape (num_edges,)
-    #         Number of states for the variables connected to each edge
-    #     """
-    #     return self.variables.values()
 
     @staticmethod
     def concatenate_wirings(wirings: Sequence) -> Wiring:

--- a/pgmax/fg/nodes.py
+++ b/pgmax/fg/nodes.py
@@ -1,7 +1,7 @@
 """A module containing classes that specify the basic components of a Factor Graph."""
 
 from dataclasses import asdict, dataclass
-from typing import OrderedDict, Sequence, Union
+from typing import List, Sequence, Tuple, Union
 
 import jax
 import jax.numpy as jnp
@@ -43,14 +43,14 @@ class Factor:
     """A factor
 
     Args:
-        vars_to_num_states: Dictionnary mapping the variables names, represented
-            in the form of a hash, to the variables number of states.
+        variables: List of variables in the factors. Each variable is represented
+            by a tuple containing the variable hash and number of states.
 
     Raises:
         NotImplementedError: If compile_wiring is not implemented
     """
 
-    vars_to_num_states: OrderedDict[int, int]
+    variables: List[Tuple[int, int]]
     log_potentials: np.ndarray
 
     def __post_init__(self):

--- a/pgmax/fg/nodes.py
+++ b/pgmax/fg/nodes.py
@@ -1,26 +1,13 @@
 """A module containing classes that specify the basic components of a Factor Graph."""
 
 from dataclasses import asdict, dataclass
-from typing import Sequence, Tuple, Union
+from typing import OrderedDict, Sequence, Union
 
 import jax
 import jax.numpy as jnp
 import numpy as np
 
 from pgmax import utils
-
-
-@dataclass(frozen=True, eq=False)
-class Variable:
-    """Base class for variables.
-    If desired, this can be sub-classed to add additional concrete
-    meta-information
-
-    Args:
-        num_states: an int representing the number of states this variable has.
-    """
-
-    num_states: int
 
 
 @jax.tree_util.register_pytree_node_class
@@ -56,13 +43,14 @@ class Factor:
     """A factor
 
     Args:
-        variables: List of connected variables
+        vars_to_num_states: Dictionnary mapping the variables names, represented
+            in the form of a hash, to the variables number of states.
 
     Raises:
         NotImplementedError: If compile_wiring is not implemented
     """
 
-    variables: Tuple[Variable, ...]
+    vars_to_num_states: OrderedDict[int, int]
     log_potentials: np.ndarray
 
     def __post_init__(self):
@@ -79,10 +67,7 @@ class Factor:
             Array of shape (num_edges,)
             Number of states for the variables connected to each edge
         """
-        edges_num_states = np.array(
-            [variable.num_states for variable in self.variables], dtype=int
-        )
-        return edges_num_states
+        return self.vars_to_num_states.values()
 
     @staticmethod
     def concatenate_wirings(wirings: Sequence) -> Wiring:

--- a/pgmax/fg/nodes.py
+++ b/pgmax/fg/nodes.py
@@ -42,7 +42,7 @@ class Factor:
 
     Args:
         variables: List of variables connected by the Factor.
-            Each variable is represented by a tuple of the form (variable hash/name, number of states)
+            Each variable is represented by a tuple (variable hash, variable num_ states)
 
     Raises:
         NotImplementedError: If compile_wiring is not implemented

--- a/pgmax/fg/nodes.py
+++ b/pgmax/fg/nodes.py
@@ -7,8 +7,6 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
-from pgmax import utils
-
 
 @jax.tree_util.register_pytree_node_class
 @dataclass(frozen=True, eq=False)
@@ -59,15 +57,15 @@ class Factor:
                 "Please implement compile_wiring in for your factor"
             )
 
-    @utils.cached_property
-    def edges_num_states(self) -> np.ndarray:
-        """Number of states for the variables connected to each edge
+    # @utils.cached_property
+    # def edges_num_states(self) -> np.ndarray:
+    #     """Number of states for the variables connected to each edge
 
-        Returns:
-            Array of shape (num_edges,)
-            Number of states for the variables connected to each edge
-        """
-        return self.vars_to_num_states.values()
+    #     Returns:
+    #         Array of shape (num_edges,)
+    #         Number of states for the variables connected to each edge
+    #     """
+    #     return self.variables.values()
 
     @staticmethod
     def concatenate_wirings(wirings: Sequence) -> Wiring:

--- a/pgmax/fg/nodes.py
+++ b/pgmax/fg/nodes.py
@@ -1,7 +1,7 @@
 """A module containing classes that specify the basic components of a Factor Graph."""
 
 from dataclasses import asdict, dataclass
-from typing import List, Sequence, Tuple, Union
+from typing import Any, List, Sequence, Tuple, Union
 
 import jax
 import jax.numpy as jnp
@@ -48,7 +48,7 @@ class Factor:
         NotImplementedError: If compile_wiring is not implemented
     """
 
-    variables: List[Tuple[int, int]]
+    variables: List[Tuple[Any, int]]
     log_potentials: np.ndarray
 
     def __post_init__(self):

--- a/pgmax/fg/nodes.py
+++ b/pgmax/fg/nodes.py
@@ -42,7 +42,7 @@ class Factor:
 
     Args:
         variables: List of variables connected by the Factor.
-            Each variable is represented by a tuple (variable hash, variable num_ states)
+            Each variable is represented by a tuple (variable hash, variable num_states)
 
     Raises:
         NotImplementedError: If compile_wiring is not implemented

--- a/pgmax/groups/enumeration.py
+++ b/pgmax/groups/enumeration.py
@@ -109,16 +109,12 @@ class EnumerationFactorGroup(groups.FactorGroup):
         num_factors = len(self.factors)
         if (
             data.shape != (num_factors, self.factor_configs.shape[0])
-            and data.shape
-            != (
-                num_factors,
-                np.sum(self.factors[0].edges_num_states),
-            )
+            and data.shape != (num_factors, np.prod(self.factor_configs.shape))
             and data.shape != (self.factor_configs.shape[0],)
         ):
             raise ValueError(
                 f"data should be of shape {(num_factors, self.factor_configs.shape[0])} or "
-                f"{(num_factors, np.sum(self.factors[0].edges_num_states))} or "
+                f"{(num_factors, np.prod(self.factor_configs.shape))} or "
                 f"{(self.factor_configs.shape[0],)}. Got {data.shape}."
             )
 

--- a/pgmax/groups/enumeration.py
+++ b/pgmax/groups/enumeration.py
@@ -231,9 +231,6 @@ class PairwiseFactorGroup(groups.FactorGroup):
                 f"Got log_potential_matrix for {log_potential_matrix.shape[0]} factors."
             )
 
-        import time
-
-        start = time.time()
         log_potential_shape = log_potential_matrix.shape[-2:]
         for variables_for_factor in self.variables_for_factors:
             if len(variables_for_factor) != 2:
@@ -252,8 +249,7 @@ class PairwiseFactorGroup(groups.FactorGroup):
                     f"configurations) does not match the specified log_potential_matrix "
                     f"(with {log_potential_shape} configurations)."
                 )
-            object.__setattr__(self, "log_potential_matrix", log_potential_matrix)
-        print(time.time() - start)
+        object.__setattr__(self, "log_potential_matrix", log_potential_matrix)
 
         factor_configs = (
             np.mgrid[

--- a/pgmax/groups/enumeration.py
+++ b/pgmax/groups/enumeration.py
@@ -80,16 +80,19 @@ class EnumerationFactorGroup(groups.FactorGroup):
         variables_to_factors = collections.OrderedDict(
             [
                 (
-                    frozenset(self.variable_names_for_factors[ii]),
+                    frozenset(variable_names_for_factor),
                     enumeration.EnumerationFactor(
-                        variables=tuple(
-                            self.variable_group[self.variable_names_for_factors[ii]]
+                        vars_to_num_states=collections.OrderedDict(
+                            (var, self.vars_to_num_states[var])
+                            for var in variable_names_for_factor
                         ),
                         factor_configs=self.factor_configs,
                         log_potentials=np.array(self.log_potentials)[ii],
                     ),
                 )
-                for ii in range(len(self.variable_names_for_factors))
+                for ii, variable_names_for_factor in enumerate(
+                    self.variable_names_for_factors
+                )
             ]
         )
         return variables_to_factors
@@ -207,12 +210,8 @@ class PairwiseFactorGroup(groups.FactorGroup):
         if self.log_potential_matrix is None:
             log_potential_matrix = np.zeros(
                 (
-                    self.variable_group[
-                        self.variable_names_for_factors[0][0]
-                    ].num_states,
-                    self.variable_group[
-                        self.variable_names_for_factors[0][1]
-                    ].num_states,
+                    self.vars_to_num_states[self.variable_names_for_factors[0][0]],
+                    self.vars_to_num_states[self.variable_names_for_factors[0][1]],
                 )
             )
         else:
@@ -245,18 +244,11 @@ class PairwiseFactorGroup(groups.FactorGroup):
                     f" {len(fac_list)} variables ({fac_list})."
                 )
 
-            # Note: num_states0 = self.variable_group[fac_list[0]] is 2x slower
-            num_states0 = self.variable_group._names_to_variables[
-                fac_list[0]
-            ].num_states
-            num_states1 = self.variable_group._names_to_variables[
-                fac_list[1]
-            ].num_states
-
+            num_states0 = self.vars_to_num_states[fac_list[0]]
+            num_states1 = self.vars_to_num_states[fac_list[1]]
             if not log_potential_matrix.shape[-2:] == (num_states0, num_states1):
                 raise ValueError(
-                    f"The specified pairwise factor {fac_list} (with "
-                    f"{(self.variable_group[fac_list[0]].num_states, self.variable_group[fac_list[1]].num_states)} "
+                    f"The specified pairwise factor {fac_list} (with {(num_states0, num_states1)}"
                     f"configurations) does not match the specified log_potential_matrix "
                     f"(with {log_potential_matrix.shape[-2:]} configurations)."
                 )
@@ -294,16 +286,19 @@ class PairwiseFactorGroup(groups.FactorGroup):
         variables_to_factors = collections.OrderedDict(
             [
                 (
-                    frozenset(self.variable_names_for_factors[ii]),
+                    frozenset(variable_names_for_factor),
                     enumeration.EnumerationFactor(
-                        variables=tuple(
-                            self.variable_group[self.variable_names_for_factors[ii]]
+                        vars_to_num_states=collections.OrderedDict(
+                            (var, self.vars_to_num_states[var])
+                            for var in variable_names_for_factor
                         ),
                         factor_configs=self.factor_configs,
                         log_potentials=self.log_potentials[ii],
                     ),
                 )
-                for ii in range(len(self.variable_names_for_factors))
+                for ii, variable_names_for_factor in enumerate(
+                    self.variable_names_for_factors
+                )
             ]
         )
         return variables_to_factors

--- a/pgmax/groups/enumeration.py
+++ b/pgmax/groups/enumeration.py
@@ -80,19 +80,14 @@ class EnumerationFactorGroup(groups.FactorGroup):
         variables_to_factors = collections.OrderedDict(
             [
                 (
-                    frozenset(variable_names_for_factor),
+                    frozenset(variables_for_factor),
                     enumeration.EnumerationFactor(
-                        vars_to_num_states=collections.OrderedDict(
-                            (var, self.vars_to_num_states[var])
-                            for var in variable_names_for_factor
-                        ),
+                        variables=variables_for_factor,
                         factor_configs=self.factor_configs,
                         log_potentials=np.array(self.log_potentials)[ii],
                     ),
                 )
-                for ii, variable_names_for_factor in enumerate(
-                    self.variable_names_for_factors
-                )
+                for ii, variables_for_factor in enumerate(self.variables_for_factors)
             ]
         )
         return variables_to_factors
@@ -188,7 +183,7 @@ class PairwiseFactorGroup(groups.FactorGroup):
     Args:
         log_potential_matrix: array of shape (var1.num_states, var2.num_states),
             where var1 and var2 are the 2 VariableGroups (that may refer to the same
-            VariableGroup) whose names are present in each sub-list from self.variable_names_for_factors.
+            VariableGroup) whose names are present in each sub-list from self.variables_for_factors.
         factor_type: Factor type shared by all the Factors in the FactorGroup.
 
     Raises:
@@ -210,8 +205,8 @@ class PairwiseFactorGroup(groups.FactorGroup):
         if self.log_potential_matrix is None:
             log_potential_matrix = np.zeros(
                 (
-                    self.vars_to_num_states[self.variable_names_for_factors[0][0]],
-                    self.vars_to_num_states[self.variable_names_for_factors[0][1]],
+                    self.variables_for_factors[0][0][1],
+                    self.variables_for_factors[0][1][1],
                 )
             )
         else:
@@ -230,25 +225,25 @@ class PairwiseFactorGroup(groups.FactorGroup):
             )
 
         if log_potential_matrix.ndim == 3 and log_potential_matrix.shape[0] != len(
-            self.variable_names_for_factors
+            self.variables_for_factors
         ):
             raise ValueError(
-                f"Expected log_potential_matrix for {len(self.variable_names_for_factors)} factors. "
+                f"Expected log_potential_matrix for {len(self.variables_for_factors)} factors. "
                 f"Got log_potential_matrix for {log_potential_matrix.shape[0]} factors."
             )
 
-        for fac_list in self.variable_names_for_factors:
-            if len(fac_list) != 2:
+        for variables_for_factor in self.variables_for_factors:
+            if len(variables_for_factor) != 2:
                 raise ValueError(
                     "All pairwise factors should connect to exactly 2 variables. Got a factor connecting to"
-                    f" {len(fac_list)} variables ({fac_list})."
+                    f" {len(variables_for_factor)} variables ({variables_for_factor})."
                 )
 
-            num_states0 = self.vars_to_num_states[fac_list[0]]
-            num_states1 = self.vars_to_num_states[fac_list[1]]
+            num_states0 = variables_for_factor[0][1]
+            num_states1 = variables_for_factor[1][1]
             if not log_potential_matrix.shape[-2:] == (num_states0, num_states1):
                 raise ValueError(
-                    f"The specified pairwise factor {fac_list} (with {(num_states0, num_states1)}"
+                    f"The specified pairwise factor {variables_for_factor} (with {(num_states0, num_states1)}"
                     f"configurations) does not match the specified log_potential_matrix "
                     f"(with {log_potential_matrix.shape[-2:]} configurations)."
                 )
@@ -264,7 +259,7 @@ class PairwiseFactorGroup(groups.FactorGroup):
         object.__setattr__(self, "factor_configs", factor_configs)
         log_potential_matrix = np.broadcast_to(
             log_potential_matrix,
-            (len(self.variable_names_for_factors),) + log_potential_matrix.shape[-2:],
+            (len(self.variables_for_factors),) + log_potential_matrix.shape[-2:],
         )
         log_potentials = np.empty(
             shape=(self.num_factors, self.factor_configs.shape[0])
@@ -286,19 +281,14 @@ class PairwiseFactorGroup(groups.FactorGroup):
         variables_to_factors = collections.OrderedDict(
             [
                 (
-                    frozenset(variable_names_for_factor),
+                    frozenset(variable_for_factor),
                     enumeration.EnumerationFactor(
-                        vars_to_num_states=collections.OrderedDict(
-                            (var, self.vars_to_num_states[var])
-                            for var in variable_names_for_factor
-                        ),
+                        variables=variable_for_factor,
                         factor_configs=self.factor_configs,
                         log_potentials=self.log_potentials[ii],
                     ),
                 )
-                for ii, variable_names_for_factor in enumerate(
-                    self.variable_names_for_factors
-                )
+                for ii, variable_for_factor in enumerate(self.variables_for_factors)
             ]
         )
         return variables_to_factors

--- a/pgmax/groups/enumeration.py
+++ b/pgmax/groups/enumeration.py
@@ -107,14 +107,17 @@ class EnumerationFactorGroup(groups.FactorGroup):
             ValueError: if data is not of the right shape.
         """
         num_factors = len(self.factors)
+        factor_edges_num_states = sum(
+            [variable[1] for variable in self.variables_for_factors[0]]
+        )
         if (
             data.shape != (num_factors, self.factor_configs.shape[0])
-            and data.shape != (num_factors, np.prod(self.factor_configs.shape))
+            and data.shape != (num_factors, factor_edges_num_states)
             and data.shape != (self.factor_configs.shape[0],)
         ):
             raise ValueError(
                 f"data should be of shape {(num_factors, self.factor_configs.shape[0])} or "
-                f"{(num_factors, np.prod(self.factor_configs.shape))} or "
+                f"{(num_factors, factor_edges_num_states)} or "
                 f"{(self.factor_configs.shape[0],)}. Got {data.shape}."
             )
 
@@ -149,18 +152,19 @@ class EnumerationFactorGroup(groups.FactorGroup):
             )
 
         num_factors = len(self.factors)
+        factor_edges_num_states = sum(
+            [variable[1] for variable in self.variables_for_factors[0]]
+        )
         if flat_data.size == num_factors * self.factor_configs.shape[0]:
             data = flat_data.reshape(
                 (num_factors, self.factor_configs.shape[0]),
             )
-        elif flat_data.size == num_factors * np.sum(self.factors[0].edges_num_states):
-            data = flat_data.reshape(
-                (num_factors, np.sum(self.factors[0].edges_num_states))
-            )
+        elif flat_data.size == num_factors * np.sum(factor_edges_num_states):
+            data = flat_data.reshape((num_factors, np.sum(factor_edges_num_states)))
         else:
             raise ValueError(
                 f"flat_data should be compatible with shape {(num_factors, self.factor_configs.shape[0])} "
-                f"or {(num_factors, np.sum(self.factors[0].edges_num_states))}. Got {flat_data.shape}."
+                f"or {(num_factors, np.sum(factor_edges_num_states))}. Got {flat_data.shape}."
             )
 
         return data

--- a/pgmax/groups/logical.py
+++ b/pgmax/groups/logical.py
@@ -34,14 +34,15 @@ class LogicalFactorGroup(groups.FactorGroup):
         variables_to_factors = collections.OrderedDict(
             [
                 (
-                    frozenset(self.variable_names_for_factors[ii]),
+                    frozenset(variable_names_for_factor),
                     self.factor_type(
-                        variables=tuple(
-                            self.variable_group[self.variable_names_for_factors[ii]]
+                        vars_to_num_states=collections.OrderedDict(
+                            (var, self.vars_to_num_states[var])
+                            for var in variable_names_for_factor
                         ),
                     ),
                 )
-                for ii in range(len(self.variable_names_for_factors))
+                for variable_names_for_factor in self.variable_names_for_factors
             ]
         )
         return variables_to_factors

--- a/pgmax/groups/logical.py
+++ b/pgmax/groups/logical.py
@@ -22,6 +22,10 @@ class LogicalFactorGroup(groups.FactorGroup):
 
     edge_states_offset: int = field(init=False)
 
+    def __post_init__(self):
+        super().__post_init__()
+        object.__setattr__(self, "factor_configs", None)
+
     def _get_variables_to_factors(
         self,
     ) -> OrderedDict[FrozenSet, logical.LogicalFactor]:

--- a/pgmax/groups/logical.py
+++ b/pgmax/groups/logical.py
@@ -4,6 +4,8 @@ import collections
 from dataclasses import dataclass, field
 from typing import FrozenSet, OrderedDict, Type
 
+import numpy as np
+
 from pgmax.factors import logical
 from pgmax.fg import groups
 
@@ -20,11 +22,8 @@ class LogicalFactorGroup(groups.FactorGroup):
             For ORFactors the edge_states_offset is 1, for ANDFactors the edge_states_offset is -1.
     """
 
+    factor_configs: np.ndarray = field(init=False, default=None)
     edge_states_offset: int = field(init=False)
-
-    def __post_init__(self):
-        super().__post_init__()
-        object.__setattr__(self, "factor_configs", None)
 
     def _get_variables_to_factors(
         self,

--- a/pgmax/groups/logical.py
+++ b/pgmax/groups/logical.py
@@ -34,15 +34,10 @@ class LogicalFactorGroup(groups.FactorGroup):
         variables_to_factors = collections.OrderedDict(
             [
                 (
-                    frozenset(variable_names_for_factor),
-                    self.factor_type(
-                        vars_to_num_states=collections.OrderedDict(
-                            (var, self.vars_to_num_states[var])
-                            for var in variable_names_for_factor
-                        ),
-                    ),
+                    frozenset(variables_for_factor),
+                    self.factor_type(variables=variables_for_factor),
                 )
-                for variable_names_for_factor in self.variable_names_for_factors
+                for variables_for_factor in self.variables_for_factors
             ]
         )
         return variables_to_factors

--- a/pgmax/groups/variables.py
+++ b/pgmax/groups/variables.py
@@ -143,7 +143,9 @@ class NDVariableArray(groups.VariableGroup):
         if flat_data.size == np.product(self.shape):
             data = flat_data.reshape(self.shape)
         elif flat_data.size == self.num_states.sum():
-            data = jnp.zeros(self.shape + (self.num_states.max(),))
+            data = jnp.full(
+                shape=self.shape + (self.num_states.max(),), fill_value=jnp.nan
+            )
             data = data.at[np.arange(data.shape[-1]) < self.num_states[..., None]].set(
                 flat_data
             )

--- a/pgmax/groups/variables.py
+++ b/pgmax/groups/variables.py
@@ -168,6 +168,15 @@ class VariableDict(groups.VariableGroup):
         return list(zip(self.variable_names, self.num_states))
 
     def __getitem__(self, val):
+        """Given a variable name retrieve the associated variable, returned via a tuple of the form
+        (variable name, number of states)
+
+        Args:
+            val: a variable index or slice
+
+        Returns:
+            The queried variable
+        """
         if val not in self.variable_names:
             raise ValueError(f"Variable {val} is not in VariableDict")
         return (val, self.num_states[0])

--- a/pgmax/groups/variables.py
+++ b/pgmax/groups/variables.py
@@ -1,19 +1,8 @@
 """A module containing the variables group classes inheriting from the base VariableGroup."""
 
-import collections
 import itertools
 from dataclasses import dataclass
-from typing import (
-    Any,
-    Dict,
-    Hashable,
-    Mapping,
-    Optional,
-    OrderedDict,
-    Set,
-    Tuple,
-    Union,
-)
+from typing import Tuple, Union
 
 import jax
 import jax.numpy as jnp

--- a/pgmax/groups/variables.py
+++ b/pgmax/groups/variables.py
@@ -28,12 +28,17 @@ class NDVariableArray(groups.VariableGroup):
     num_states: np.ndarray
 
     def __post_init__(self):
-        if isinstance(self.num_states, int):
+        if np.isscalar(self.num_states) and np.issubdtype(type(np.int64(10)), int):
             num_states = np.full(self.shape, fill_value=self.num_states)
             object.__setattr__(self, "num_states", num_states)
-        elif isinstance(self.num_states, np.ndarray):
+        elif isinstance(self.num_states, np.ndarray) and np.issubdtype(
+            self.num_states.dtype, int
+        ):
             if self.num_states.shape != self.shape:
                 raise ValueError("Should be same shape")
+        else:
+            raise ValueError("num_states entries should be of type np.int")
+
         random_hash = random.randint(0, 2**63)
         object.__setattr__(self, "random_hash", random_hash)
 

--- a/pgmax/groups/variables.py
+++ b/pgmax/groups/variables.py
@@ -212,7 +212,7 @@ class VariableDict(groups.VariableGroup):
         return (self.variable_hashes[var_idx], self.num_states[var_idx])
 
     def flatten(
-        self, data: Mapping[Tuple[Tuple[int, int], int], Union[np.ndarray, jnp.ndarray]]
+        self, data: Mapping[Any, Union[np.ndarray, jnp.ndarray]]
     ) -> jnp.ndarray:
         """Function that turns meaningful structured data into a flat data array for internal use.
 

--- a/pgmax/groups/variables.py
+++ b/pgmax/groups/variables.py
@@ -3,17 +3,27 @@
 import collections
 import itertools
 from dataclasses import dataclass
-from typing import Any, Dict, Hashable, Mapping, OrderedDict, Tuple, Union
+from typing import (
+    Any,
+    Dict,
+    Hashable,
+    Mapping,
+    Optional,
+    OrderedDict,
+    Set,
+    Tuple,
+    Union,
+)
 
 import jax
 import jax.numpy as jnp
 import numpy as np
 
-from pgmax.fg import groups, nodes
+from pgmax.utils import cached_property
 
 
 @dataclass(frozen=True, eq=False)
-class NDVariableArray(groups.VariableGroup):
+class NDVariableArray:
     """Subclass of VariableGroup for n-dimensional grids of variables.
 
     Args:
@@ -22,27 +32,37 @@ class NDVariableArray(groups.VariableGroup):
             the notion of a NumPy ndarray shape)
     """
 
-    num_states: int
     shape: Tuple[int, ...]
+    num_states: Union[int, np.ndarray]
 
-    def _get_names_to_variables(
-        self,
-    ) -> OrderedDict[Union[int, Tuple[int, ...]], nodes.Variable]:
+    def __post_init__(self):
+        # super().__post_init__()
+
+        if isinstance(self.num_states, int):
+            num_states = np.full(self.shape, fill_value=self.num_states)
+            object.__setattr__(self, "num_states", num_states)
+        elif isinstance(self.num_states, np.ndarray):
+            if self.num_states.shape != self.shape:
+                raise ValueError("Should be same shape")
+
+    @cached_property
+    def variable_names(self) -> np.ndarray:
         """Function that generates a dictionary mapping names to variables.
 
         Returns:
             a dictionary mapping all possible names to different variables.
         """
-        names_to_variables: OrderedDict[
-            Union[int, Tuple[int, ...]], nodes.Variable
-        ] = collections.OrderedDict()
-        for name in itertools.product(*[list(range(k)) for k in self.shape]):
-            if len(name) == 1:
-                names_to_variables[name[0]] = nodes.Variable(self.num_states)
-            else:
-                names_to_variables[name] = nodes.Variable(self.num_states)
+        variable_names = np.empty(self.shape, dtype=int)
+        self_hash = self.__hash__()
+        for index in itertools.product(*[list(range(k)) for k in self.shape]):
+            name = hash((self_hash, index))
+            variable_names[index] = name
+        return variable_names
 
-        return names_to_variables
+    def __getitem__(self, val):
+        # Numpy indexation will throw IndexError is out-of-bounds
+        # This will be used to add FactorGroups
+        return self.variable_names[val]
 
     def flatten(self, data: Union[np.ndarray, jnp.ndarray]) -> jnp.ndarray:
         """Function that turns meaningful structured data into a flat data array for internal use.
@@ -57,12 +77,14 @@ class NDVariableArray(groups.VariableGroup):
         Raises:
             ValueError: If the data is not of the correct shape.
         """
-        if data.shape != self.shape and data.shape != self.shape + (self.num_states,):
+        # TODO: what should we do for different number of states
+        if data.shape != self.shape and data.shape != self.shape + (
+            self.num_states.max(),
+        ):
             raise ValueError(
-                f"data should be of shape {self.shape} or {self.shape + (self.num_states,)}. "
+                f"data should be of shape {self.shape} or {self.shape + (self.num_states.max(),)}. "
                 f"Got {data.shape}."
             )
-
         return jax.device_put(data).flatten()
 
     def unflatten(
@@ -89,8 +111,9 @@ class NDVariableArray(groups.VariableGroup):
 
         if flat_data.size == np.product(self.shape):
             data = flat_data.reshape(self.shape)
-        elif flat_data.size == np.product(self.shape) * self.num_states:
-            data = flat_data.reshape(self.shape + (self.num_states,))
+        elif flat_data.size == self.num_states.sum():
+            # TODO: what should we dot for different number of states
+            data = flat_data.reshape(self.shape + (self.num_states.max(),))
         else:
             raise ValueError(
                 f"flat_data should be compatible with shape {self.shape} or {self.shape + (self.num_states,)}. "
@@ -100,110 +123,110 @@ class NDVariableArray(groups.VariableGroup):
         return data
 
 
-@dataclass(frozen=True, eq=False)
-class VariableDict(groups.VariableGroup):
-    """A variable dictionary that contains a set of variables of the same size
+# @dataclass(frozen=True, eq=False)
+# class VariableDict(groups.VariableGroup):
+#     """A variable dictionary that contains a set of variables of the same size
 
-    Args:
-        num_states: The size of the variables in this variable group
-        variable_names: A tuple of all names of the variables in this variable group
+#     Args:
+#         num_states: The size of the variables in this variable group
+#         variable_names: A tuple of all names of the variables in this variable group
 
-    """
+#     """
 
-    num_states: int
-    variable_names: Tuple[Any, ...]
+#     num_states: int
+#     variable_names: Tuple[Any, ...]
 
-    def _get_names_to_variables(self) -> OrderedDict[Tuple[int, ...], nodes.Variable]:
-        """Function that generates a dictionary mapping names to variables.
+#     def _get_names_to_variables(self) -> OrderedDict[Tuple[int, ...], nodes.Variable]:
+#         """Function that generates a dictionary mapping names to variables.
 
-        Returns:
-            a dictionary mapping all possible names to different variables.
-        """
-        names_to_variables: OrderedDict[
-            Tuple[Any, ...], nodes.Variable
-        ] = collections.OrderedDict()
-        for name in self.variable_names:
-            names_to_variables[name] = nodes.Variable(self.num_states)
+#         Returns:
+#             a dictionary mapping all possible names to different variables.
+#         """
+#         names_to_variables: OrderedDict[
+#             Tuple[Any, ...], nodes.Variable
+#         ] = collections.OrderedDict()
+#         for name in self.variable_names:
+#             names_to_variables[name] = nodes.Variable(self.num_states)
 
-        return names_to_variables
+#         return names_to_variables
 
-    def flatten(
-        self, data: Mapping[Hashable, Union[np.ndarray, jnp.ndarray]]
-    ) -> jnp.ndarray:
-        """Function that turns meaningful structured data into a flat data array for internal use.
+#     def flatten(
+#         self, data: Mapping[Hashable, Union[np.ndarray, jnp.ndarray]]
+#     ) -> jnp.ndarray:
+#         """Function that turns meaningful structured data into a flat data array for internal use.
 
-        Args:
-            data: Meaningful structured data. Should be a mapping with names from self.variable_names.
-                Each value should be an array of shape (1,) (for e.g. MAP decodings) or
-                (self.num_states,) (for e.g. evidence, beliefs).
+#         Args:
+#             data: Meaningful structured data. Should be a mapping with names from self.variable_names.
+#                 Each value should be an array of shape (1,) (for e.g. MAP decodings) or
+#                 (self.num_states,) (for e.g. evidence, beliefs).
 
-        Returns:
-            A flat jnp.array for internal use
+#         Returns:
+#             A flat jnp.array for internal use
 
-        Raises:
-            ValueError if:
-                (1) data is referring to a non-existing variable
-                (2) data is not of the correct shape
-        """
-        for name in data:
-            if name not in self._names_to_variables:
-                raise ValueError(
-                    f"data is referring to a non-existent variable {name}."
-                )
+#         Raises:
+#             ValueError if:
+#                 (1) data is referring to a non-existing variable
+#                 (2) data is not of the correct shape
+#         """
+#         for name in data:
+#             if name not in self._names_to_variables:
+#                 raise ValueError(
+#                     f"data is referring to a non-existent variable {name}."
+#                 )
 
-            if data[name].shape != (self.num_states,) and data[name].shape != (1,):
-                raise ValueError(
-                    f"Variable {name} expects a data array of shape "
-                    f"{(self.num_states,)} or (1,). Got {data[name].shape}."
-                )
+#             if data[name].shape != (self.num_states,) and data[name].shape != (1,):
+#                 raise ValueError(
+#                     f"Variable {name} expects a data array of shape "
+#                     f"{(self.num_states,)} or (1,). Got {data[name].shape}."
+#                 )
 
-        flat_data = jnp.concatenate([data[name].flatten() for name in self.names])
-        return flat_data
+#         flat_data = jnp.concatenate([data[name].flatten() for name in self.names])
+#         return flat_data
 
-    def unflatten(
-        self, flat_data: Union[np.ndarray, jnp.ndarray]
-    ) -> Dict[Hashable, Union[np.ndarray, jnp.ndarray]]:
-        """Function that recovers meaningful structured data from internal flat data array
+#     def unflatten(
+#         self, flat_data: Union[np.ndarray, jnp.ndarray]
+#     ) -> Dict[Hashable, Union[np.ndarray, jnp.ndarray]]:
+#         """Function that recovers meaningful structured data from internal flat data array
 
-        Args:
-            flat_data: Internal flat data array.
+#         Args:
+#             flat_data: Internal flat data array.
 
-        Returns:
-            Meaningful structured data. Should be a mapping with names from self.variable_names.
-                Each value should be an array of shape (1,) (for e.g. MAP decodings) or
-                (self.num_states,) (for e.g. evidence, beliefs).
+#         Returns:
+#             Meaningful structured data. Should be a mapping with names from self.variable_names.
+#                 Each value should be an array of shape (1,) (for e.g. MAP decodings) or
+#                 (self.num_states,) (for e.g. evidence, beliefs).
 
-        Raises:
-            ValueError if:
-                (1) flat_data is not a 1D array
-                (2) flat_data is not of the right shape
-        """
-        if flat_data.ndim != 1:
-            raise ValueError(
-                f"Can only unflatten 1D array. Got a {flat_data.ndim}D array."
-            )
+#         Raises:
+#             ValueError if:
+#                 (1) flat_data is not a 1D array
+#                 (2) flat_data is not of the right shape
+#         """
+#         if flat_data.ndim != 1:
+#             raise ValueError(
+#                 f"Can only unflatten 1D array. Got a {flat_data.ndim}D array."
+#             )
 
-        num_variables = len(self.variable_names)
-        num_variable_states = len(self.variable_names) * self.num_states
-        if flat_data.shape[0] == num_variables:
-            use_num_states = False
-        elif flat_data.shape[0] == num_variable_states:
-            use_num_states = True
-        else:
-            raise ValueError(
-                f"flat_data should be either of shape (num_variables(={len(self.variables)}),), "
-                f"or (num_variable_states(={num_variable_states}),). "
-                f"Got {flat_data.shape}"
-            )
+#         num_variables = len(self.variable_names)
+#         num_variable_states = len(self.variable_names) * self.num_states
+#         if flat_data.shape[0] == num_variables:
+#             use_num_states = False
+#         elif flat_data.shape[0] == num_variable_states:
+#             use_num_states = True
+#         else:
+#             raise ValueError(
+#                 f"flat_data should be either of shape (num_variables(={len(self.variables)}),), "
+#                 f"or (num_variable_states(={num_variable_states}),). "
+#                 f"Got {flat_data.shape}"
+#             )
 
-        start = 0
-        data = {}
-        for name in self.variable_names:
-            if use_num_states:
-                data[name] = flat_data[start : start + self.num_states]
-                start += self.num_states
-            else:
-                data[name] = flat_data[np.array([start])]
-                start += 1
+#         start = 0
+#         data = {}
+#         for name in self.variable_names:
+#             if use_num_states:
+#                 data[name] = flat_data[start : start + self.num_states]
+#                 start += self.num_states
+#             else:
+#                 data[name] = flat_data[np.array([start])]
+#                 start += 1
 
-        return data
+#         return data

--- a/pgmax/groups/variables.py
+++ b/pgmax/groups/variables.py
@@ -3,7 +3,7 @@
 import random
 from dataclasses import dataclass
 from functools import total_ordering
-from typing import Any, List, Tuple, Union
+from typing import Any, Dict, Hashable, List, Mapping, Tuple, Union
 
 import jax
 import jax.numpy as jnp
@@ -28,8 +28,6 @@ class NDVariableArray(groups.VariableGroup):
     num_states: np.ndarray
 
     def __post_init__(self):
-        # super().__post_init__()
-
         if isinstance(self.num_states, int):
             num_states = np.full(self.shape, fill_value=self.num_states)
             object.__setattr__(self, "num_states", num_states)
@@ -124,7 +122,7 @@ class NDVariableArray(groups.VariableGroup):
             data = flat_data.reshape(self.shape + (self.num_states.max(),))
         else:
             raise ValueError(
-                f"flat_data should be compatible with shape {self.shape} or {self.shape + (self.num_states,)}. "
+                f"flat_data should be compatible with shape {self.shape} or {self.shape + (self.num_states.max(),)}. "
                 f"Got {flat_data.shape}."
             )
 
@@ -140,8 +138,8 @@ class VariableDict(groups.VariableGroup):
         variable_names: A tuple of all names of the variables in this variable group
     """
 
-    num_states: int
     variable_names: Tuple[Any, ...]
+    num_states: int
 
     @cached_property
     def variables(self) -> List[Tuple]:
@@ -153,83 +151,85 @@ class VariableDict(groups.VariableGroup):
         # Numpy indexation will throw IndexError for us if out-of-bounds
         return (val, self.num_states)
 
-    # def flatten(
-    #     self, data: Mapping[Hashable, Union[np.ndarray, jnp.ndarray]]
-    # ) -> jnp.ndarray:
-    #     """Function that turns meaningful structured data into a flat data array for internal use.
+    def flatten(
+        self, data: Mapping[Hashable, Union[np.ndarray, jnp.ndarray]]
+    ) -> jnp.ndarray:
+        """Function that turns meaningful structured data into a flat data array for internal use.
 
-    #     Args:
-    #         data: Meaningful structured data. Should be a mapping with names from self.variable_names.
-    #             Each value should be an array of shape (1,) (for e.g. MAP decodings) or
-    #             (self.num_states,) (for e.g. evidence, beliefs).
+        Args:
+            data: Meaningful structured data. Should be a mapping with names from self.variable_names.
+                Each value should be an array of shape (1,) (for e.g. MAP decodings) or
+                (self.num_states,) (for e.g. evidence, beliefs).
 
-    #     Returns:
-    #         A flat jnp.array for internal use
+        Returns:
+            A flat jnp.array for internal use
 
-    #     Raises:
-    #         ValueError if:
-    #             (1) data is referring to a non-existing variable
-    #             (2) data is not of the correct shape
-    #     """
-    #     for name in data:
-    #         if name not in self.variable_names:
-    #             raise ValueError(
-    #                 f"data is referring to a non-existent variable {name}."
-    #             )
+        Raises:
+            ValueError if:
+                (1) data is referring to a non-existing variable
+                (2) data is not of the correct shape
+        """
+        for name in data:
+            if name not in self.variable_names:
+                raise ValueError(
+                    f"data is referring to a non-existent variable {name}."
+                )
 
-    #         if data[name].shape != (self.num_states,) and data[name].shape != (1,):
-    #             raise ValueError(
-    #                 f"Variable {name} expects a data array of shape "
-    #                 f"{(self.num_states,)} or (1,). Got {data[name].shape}."
-    #             )
+            if data[name].shape != (self.num_states,) and data[name].shape != (1,):
+                raise ValueError(
+                    f"Variable {name} expects a data array of shape "
+                    f"{(self.num_states,)} or (1,). Got {data[name].shape}."
+                )
 
-    #     flat_data = jnp.concatenate([data[name].flatten() for name in self.variable_names])
-    #     return flat_data
+        flat_data = jnp.concatenate(
+            [data[name].flatten() for name in self.variable_names]
+        )
+        return flat_data
 
-    # def unflatten(
-    #     self, flat_data: Union[np.ndarray, jnp.ndarray]
-    # ) -> Dict[Hashable, Union[np.ndarray, jnp.ndarray]]:
-    #     """Function that recovers meaningful structured data from internal flat data array
+    def unflatten(
+        self, flat_data: Union[np.ndarray, jnp.ndarray]
+    ) -> Dict[Hashable, Union[np.ndarray, jnp.ndarray]]:
+        """Function that recovers meaningful structured data from internal flat data array
 
-    #     Args:
-    #         flat_data: Internal flat data array.
+        Args:
+            flat_data: Internal flat data array.
 
-    #     Returns:
-    #         Meaningful structured data. Should be a mapping with names from self.variable_names.
-    #             Each value should be an array of shape (1,) (for e.g. MAP decodings) or
-    #             (self.num_states,) (for e.g. evidence, beliefs).
+        Returns:
+            Meaningful structured data. Should be a mapping with names from self.variable_names.
+                Each value should be an array of shape (1,) (for e.g. MAP decodings) or
+                (self.num_states,) (for e.g. evidence, beliefs).
 
-    #     Raises:
-    #         ValueError if:
-    #             (1) flat_data is not a 1D array
-    #             (2) flat_data is not of the right shape
-    #     """
-    #     if flat_data.ndim != 1:
-    #         raise ValueError(
-    #             f"Can only unflatten 1D array. Got a {flat_data.ndim}D array."
-    #         )
+        Raises:
+            ValueError if:
+                (1) flat_data is not a 1D array
+                (2) flat_data is not of the right shape
+        """
+        if flat_data.ndim != 1:
+            raise ValueError(
+                f"Can only unflatten 1D array. Got a {flat_data.ndim}D array."
+            )
 
-    #     num_variables = len(self.variable_names)
-    #     num_variable_states = len(self.variable_names) * self.num_states
-    #     if flat_data.shape[0] == num_variables:
-    #         use_num_states = False
-    #     elif flat_data.shape[0] == num_variable_states:
-    #         use_num_states = True
-    #     else:
-    #         raise ValueError(
-    #             f"flat_data should be either of shape (num_variables(={len(self.variables)}),), "
-    #             f"or (num_variable_states(={num_variable_states}),). "
-    #             f"Got {flat_data.shape}"
-    #         )
+        num_variables = len(self.variable_names)
+        num_variable_states = len(self.variable_names) * self.num_states
+        if flat_data.shape[0] == num_variables:
+            use_num_states = False
+        elif flat_data.shape[0] == num_variable_states:
+            use_num_states = True
+        else:
+            raise ValueError(
+                f"flat_data should be either of shape (num_variables(={len(self.variables)}),), "
+                f"or (num_variable_states(={num_variable_states}),). "
+                f"Got {flat_data.shape}"
+            )
 
-    #     start = 0
-    #     data = {}
-    #     for name in self.variable_names:
-    #         if use_num_states:
-    #             data[name] = flat_data[start : start + self.num_states]
-    #             start += self.num_states
-    #         else:
-    #             data[name] = flat_data[np.array([start])]
-    #             start += 1
+        start = 0
+        data = {}
+        for name in self.variable_names:
+            if use_num_states:
+                data[name] = flat_data[start : start + self.num_states]
+                start += self.num_states
+            else:
+                data[name] = flat_data[np.array([start])]
+                start += 1
 
-    #     return data
+        return data

--- a/pgmax/groups/variables.py
+++ b/pgmax/groups/variables.py
@@ -148,7 +148,8 @@ class VariableDict(groups.VariableGroup):
         )
 
     def __getitem__(self, val):
-        # Numpy indexation will throw IndexError for us if out-of-bounds
+        if val not in self.variable_names:
+            raise ValueError(f"Variable {val} is not in VariableDict")
         return (val, self.num_states)
 
     def flatten(
@@ -170,7 +171,7 @@ class VariableDict(groups.VariableGroup):
                 (2) data is not of the correct shape
         """
         for name in data:
-            if name not in self.variable_names:
+            if name not in self.variables:
                 raise ValueError(
                     f"data is referring to a non-existent variable {name}."
                 )
@@ -181,9 +182,7 @@ class VariableDict(groups.VariableGroup):
                     f"{(self.num_states,)} or (1,). Got {data[name].shape}."
                 )
 
-        flat_data = jnp.concatenate(
-            [data[name].flatten() for name in self.variable_names]
-        )
+        flat_data = jnp.concatenate([data[name].flatten() for name in self.variables])
         return flat_data
 
     def unflatten(

--- a/pgmax/groups/variables.py
+++ b/pgmax/groups/variables.py
@@ -22,7 +22,6 @@ class NDVariableArray(groups.VariableGroup):
             the notion of a NumPy ndarray shape)
     """
 
-    num_states: Union[int, np.ndarray]
     shape: Tuple[int, ...]
 
     def __post_init__(self):
@@ -161,7 +160,6 @@ class VariableDict(groups.VariableGroup):
         variable_names: A tuple of all the names of the variables in this VariableGroup.
     """
 
-    num_states: Union[int, np.ndarray]
     variable_names: Tuple[Any, ...]
 
     def __post_init__(self):

--- a/tests/factors/test_and.py
+++ b/tests/factors/test_and.py
@@ -45,14 +45,18 @@ def test_run_bp_with_ANDFactors():
             num_states=2, shape=(num_parents.sum(),)
         )
         children_variables1 = vgroup.NDVariableArray(num_states=2, shape=(num_factors,))
-        fg1 = graph.FactorGraph(variables=[parents_variables1, children_variables1])
+        fg1 = graph.FactorGraph(
+            variable_groups=[parents_variables1, children_variables1]
+        )
 
         # Graph 2
         parents_variables2 = vgroup.NDVariableArray(
             num_states=2, shape=(num_parents.sum(),)
         )
         children_variables2 = vgroup.NDVariableArray(num_states=2, shape=(num_factors,))
-        fg2 = graph.FactorGraph(variables=[parents_variables2, children_variables2])
+        fg2 = graph.FactorGraph(
+            variable_groups=[parents_variables2, children_variables2]
+        )
 
         # Option 1: Define EnumerationFactors equivalent to the ANDFactors
         variables_for_factors1 = []
@@ -100,7 +104,7 @@ def test_run_bp_with_ANDFactors():
                     factor_configs=valid_configs,
                     log_potentials=np.zeros(valid_configs.shape[0]),
                 )
-                fg1.add_factor(enum_factor)
+                fg1.add_factors(factor=enum_factor)
             else:
                 if idx != 0:
                     # Add the second half of factors to FactorGraph2
@@ -109,7 +113,7 @@ def test_run_bp_with_ANDFactors():
                         factor_configs=valid_configs,
                         log_potentials=np.zeros(valid_configs.shape[0]),
                     )
-                    fg2.add_factor(enum_factor)
+                    fg2.add_factors(factor=enum_factor)
                 else:
                     # Add all the EnumerationFactors to FactorGraph1 for the first iter
                     enum_factor = EnumerationFactor(
@@ -117,7 +121,7 @@ def test_run_bp_with_ANDFactors():
                         factor_configs=valid_configs,
                         log_potentials=np.zeros(valid_configs.shape[0]),
                     )
-                    fg1.add_factor(enum_factor)
+                    fg1.add_factors(factor=enum_factor)
 
         # Option 2: Define the ANDFactors
         num_parents_cumsum = np.insert(np.cumsum(num_parents), 0, 0)
@@ -141,10 +145,10 @@ def test_run_bp_with_ANDFactors():
                     )
         if idx != 0:
             factor_group = logical.ANDFactorGroup(variables_for_ANDFactors_fg1)
-            fg1.add_factor_group(factor_group)
+            fg1.add_factors(factor_group)
 
         factor_group = logical.ANDFactorGroup(variables_for_ANDFactors_fg2)
-        fg2.add_factor_group(factor_group)
+        fg2.add_factors(factor_group)
 
         # Run inference
         bp1 = graph.BP(fg1.bp_state, temperature=temperature)

--- a/tests/factors/test_and.py
+++ b/tests/factors/test_and.py
@@ -58,23 +58,23 @@ def test_run_bp_with_ANDFactors():
         variables_for_factors1 = []
         variables_for_factors2 = []
         for factor_idx in range(num_factors):
-            variable_names1 = [
+            variables1 = [
                 parents_variables1[idx]
                 for idx in range(
                     num_parents_cumsum[factor_idx],
                     num_parents_cumsum[factor_idx + 1],
                 )
             ] + [children_variables1[factor_idx]]
-            variables_for_factors1.append(variable_names1)
+            variables_for_factors1.append(variables1)
 
-            variable_names2 = [
+            variables2 = [
                 parents_variables2[idx]
                 for idx in range(
                     num_parents_cumsum[factor_idx],
                     num_parents_cumsum[factor_idx + 1],
                 )
             ] + [children_variables2[factor_idx]]
-            variables_for_factors2.append(variable_names2)
+            variables_for_factors2.append(variables2)
 
         # Option 1: Define EnumerationFactors equivalent to the ANDFactors
         for factor_idx in range(num_factors):
@@ -96,7 +96,7 @@ def test_run_bp_with_ANDFactors():
             if factor_idx < num_factors // 2:
                 # Add the first half of factors to FactorGraph1
                 fg1.add_factor(
-                    variable_names=variables_for_factors1[factor_idx],
+                    variables=variables_for_factors1[factor_idx],
                     factor_configs=valid_configs,
                     log_potentials=np.zeros(valid_configs.shape[0]),
                 )
@@ -104,14 +104,14 @@ def test_run_bp_with_ANDFactors():
                 if idx != 0:
                     # Add the second half of factors to FactorGraph2
                     fg2.add_factor(
-                        variable_names=variables_for_factors2[factor_idx],
+                        variables=variables_for_factors2[factor_idx],
                         factor_configs=valid_configs,
                         log_potentials=np.zeros(valid_configs.shape[0]),
                     )
                 else:
                     # Add all the EnumerationFactors to FactorGraph1 for the first iter
                     fg1.add_factor(
-                        variable_names=variables_for_factors1[factor_idx],
+                        variables=variables_for_factors1[factor_idx],
                         factor_configs=valid_configs,
                         log_potentials=np.zeros(valid_configs.shape[0]),
                     )

--- a/tests/factors/test_and.py
+++ b/tests/factors/test_and.py
@@ -8,14 +8,14 @@ from pgmax.groups import logical
 from pgmax.groups import variables as vgroup
 
 
-def test_run_bp_with_AND_factors():
+def test_run_bp_with_ANDFactors():
     """
     Simultaneously test
     (1) the support of ANDFactors in a FactorGraph and their specialized inference for different temperatures
     (2) the support of several factor types in a FactorGraph and during inference
 
     To do so, observe that an ANDFactor can be defined as an equivalent EnumerationFactor
-    (which list all the valid AND configurations) and define two equivalent FactorGraphs
+    (which list all the valid OR configurations) and define two equivalent FactorGraphs
     FG1: first half of factors are defined as EnumerationFactors, second half are defined as ANDFactors
     FG2: first half of factors are defined as ANDFactors, second half are defined as EnumerationFactors
 
@@ -25,6 +25,7 @@ def test_run_bp_with_AND_factors():
     Note: for the first seed, add all the EnumerationFactors to FG1 and all the ANDFactors to FG2
     """
     for idx in range(10):
+        print("it", idx)
         np.random.seed(idx)
 
         # Parameters
@@ -43,30 +44,41 @@ def test_run_bp_with_AND_factors():
         parents_variables1 = vgroup.NDVariableArray(
             num_states=2, shape=(num_parents.sum(),)
         )
-        children_variable1 = vgroup.NDVariableArray(num_states=2, shape=(num_factors,))
-        fg1 = graph.FactorGraph(
-            variables=dict(parents=parents_variables1, children=children_variable1)
-        )
+        children_variables1 = vgroup.NDVariableArray(num_states=2, shape=(num_factors,))
+        fg1 = graph.FactorGraph(variables=[parents_variables1, children_variables1])
 
         # Graph 2
         parents_variables2 = vgroup.NDVariableArray(
             num_states=2, shape=(num_parents.sum(),)
         )
-        children_variable2 = vgroup.NDVariableArray(num_states=2, shape=(num_factors,))
-        fg2 = graph.FactorGraph(
-            variables=dict(parents=parents_variables2, children=children_variable2)
-        )
+        children_variables2 = vgroup.NDVariableArray(num_states=2, shape=(num_factors,))
+        fg2 = graph.FactorGraph(variables=[parents_variables2, children_variables2])
 
-        # Option 1: Define EnumerationFactors equivalent to the ANDFactors
+        # Variable names for factors
+        variables_for_factors1 = []
+        variables_for_factors2 = []
         for factor_idx in range(num_factors):
-            this_num_parents = num_parents[factor_idx]
-            variable_names = [
-                ("parents", idx)
+            variable_names1 = [
+                parents_variables1[idx]
                 for idx in range(
                     num_parents_cumsum[factor_idx],
                     num_parents_cumsum[factor_idx + 1],
                 )
-            ] + [("children", factor_idx)]
+            ] + [children_variables1[factor_idx]]
+            variables_for_factors1.append(variable_names1)
+
+            variable_names2 = [
+                parents_variables2[idx]
+                for idx in range(
+                    num_parents_cumsum[factor_idx],
+                    num_parents_cumsum[factor_idx + 1],
+                )
+            ] + [children_variables2[factor_idx]]
+            variables_for_factors2.append(variable_names2)
+
+        # Option 1: Define EnumerationFactors equivalent to the ANDFactors
+        for factor_idx in range(num_factors):
+            this_num_parents = num_parents[factor_idx]
 
             configs = np.array(list(product([0, 1], repeat=this_num_parents + 1)))
             # Children state is last
@@ -84,7 +96,7 @@ def test_run_bp_with_AND_factors():
             if factor_idx < num_factors // 2:
                 # Add the first half of factors to FactorGraph1
                 fg1.add_factor(
-                    variable_names=variable_names,
+                    variable_names=variables_for_factors1[factor_idx],
                     factor_configs=valid_configs,
                     log_potentials=np.zeros(valid_configs.shape[0]),
                 )
@@ -92,73 +104,76 @@ def test_run_bp_with_AND_factors():
                 if idx != 0:
                     # Add the second half of factors to FactorGraph2
                     fg2.add_factor(
-                        variable_names=variable_names,
+                        variable_names=variables_for_factors2[factor_idx],
                         factor_configs=valid_configs,
                         log_potentials=np.zeros(valid_configs.shape[0]),
                     )
                 else:
                     # Add all the EnumerationFactors to FactorGraph1 for the first iter
                     fg1.add_factor(
-                        variable_names=variable_names,
+                        variable_names=variables_for_factors1[factor_idx],
                         factor_configs=valid_configs,
                         log_potentials=np.zeros(valid_configs.shape[0]),
                     )
 
         # Option 2: Define the ANDFactors
         num_parents_cumsum = np.insert(np.cumsum(num_parents), 0, 0)
-        variable_names_for_ANDFactors_fg1 = []
-        variable_names_for_ANDFactors_fg2 = []
+        variables_for_ANDFactors_fg1 = []
+        variables_for_ANDFactors_fg2 = []
 
         for factor_idx in range(num_factors):
-            variables_names_for_ANDFactor = [
-                ("parents", idx)
-                for idx in range(
-                    num_parents_cumsum[factor_idx],
-                    num_parents_cumsum[factor_idx + 1],
-                )
-            ] + [("children", factor_idx)]
             if factor_idx < num_factors // 2:
                 # Add the first half of factors to FactorGraph2
-                variable_names_for_ANDFactors_fg2.append(variables_names_for_ANDFactor)
+                variables_for_ANDFactors_fg2.append(variables_for_factors2[factor_idx])
             else:
                 if idx != 0:
                     # Add the second half of factors to FactorGraph1
-                    variable_names_for_ANDFactors_fg1.append(
-                        variables_names_for_ANDFactor
+                    variables_for_ANDFactors_fg1.append(
+                        variables_for_factors1[factor_idx]
                     )
                 else:
                     # Add all the ANDFactors to FactorGraph2 for the first iter
-                    variable_names_for_ANDFactors_fg2.append(
-                        variables_names_for_ANDFactor
+                    variables_for_ANDFactors_fg2.append(
+                        variables_for_factors2[factor_idx]
                     )
-
         if idx != 0:
             fg1.add_factor_group(
                 factory=logical.ANDFactorGroup,
-                variable_names_for_factors=variable_names_for_ANDFactors_fg1,
+                variables_for_factors=variables_for_ANDFactors_fg1,
             )
         fg2.add_factor_group(
             factory=logical.ANDFactorGroup,
-            variable_names_for_factors=variable_names_for_ANDFactors_fg2,
+            variables_for_factors=variables_for_ANDFactors_fg2,
         )
 
         # Run inference
         bp1 = graph.BP(fg1.bp_state, temperature=temperature)
         bp2 = graph.BP(fg2.bp_state, temperature=temperature)
 
-        evidence_updates = {
-            "parents": jax.device_put(np.random.gumbel(size=(sum(num_parents), 2))),
-            "children": jax.device_put(np.random.gumbel(size=(num_factors, 2))),
+        evidence_parents = jax.device_put(np.random.gumbel(size=(sum(num_parents), 2)))
+        evidence_children = jax.device_put(np.random.gumbel(size=(num_factors, 2)))
+
+        evidence_updates1 = {
+            parents_variables1: evidence_parents,
+            children_variables1: evidence_children,
+        }
+        evidence_updates2 = {
+            parents_variables2: evidence_parents,
+            children_variables2: evidence_children,
         }
 
-        bp_arrays1 = bp1.init(evidence_updates=evidence_updates)
+        bp_arrays1 = bp1.init(evidence_updates=evidence_updates1)
         bp_arrays1 = bp1.run_bp(bp_arrays1, num_iters=5)
-        bp_arrays2 = bp2.init(evidence_updates=evidence_updates)
+        bp_arrays2 = bp2.init(evidence_updates=evidence_updates2)
         bp_arrays2 = bp2.run_bp(bp_arrays2, num_iters=5)
 
         # Get beliefs
         beliefs1 = bp1.get_beliefs(bp_arrays1)
         beliefs2 = bp2.get_beliefs(bp_arrays2)
 
-        assert np.allclose(beliefs1["children"], beliefs2["children"], atol=1e-4)
-        assert np.allclose(beliefs1["parents"], beliefs2["parents"], atol=1e-4)
+        assert np.allclose(
+            beliefs1[children_variables1], beliefs2[children_variables2], atol=1e-4
+        )
+        assert np.allclose(
+            beliefs1[parents_variables1], beliefs2[parents_variables2], atol=1e-4
+        )

--- a/tests/factors/test_and.py
+++ b/tests/factors/test_and.py
@@ -15,7 +15,7 @@ def test_run_bp_with_ANDFactors():
     (2) the support of several factor types in a FactorGraph and during inference
 
     To do so, observe that an ANDFactor can be defined as an equivalent EnumerationFactor
-    (which list all the valid OR configurations) and define two equivalent FactorGraphs
+    (which list all the valid AND configurations) and define two equivalent FactorGraphs
     FG1: first half of factors are defined as EnumerationFactors, second half are defined as ANDFactors
     FG2: first half of factors are defined as ANDFactors, second half are defined as EnumerationFactors
 
@@ -25,7 +25,6 @@ def test_run_bp_with_ANDFactors():
     Note: for the first seed, add all the EnumerationFactors to FG1 and all the ANDFactors to FG2
     """
     for idx in range(10):
-        print("it", idx)
         np.random.seed(idx)
 
         # Parameters
@@ -54,7 +53,7 @@ def test_run_bp_with_ANDFactors():
         children_variables2 = vgroup.NDVariableArray(num_states=2, shape=(num_factors,))
         fg2 = graph.FactorGraph(variables=[parents_variables2, children_variables2])
 
-        # Variable names for factors
+        # Option 1: Define EnumerationFactors equivalent to the ANDFactors
         variables_for_factors1 = []
         variables_for_factors2 = []
         for factor_idx in range(num_factors):

--- a/tests/factors/test_and.py
+++ b/tests/factors/test_and.py
@@ -3,6 +3,7 @@ from itertools import product
 import jax
 import numpy as np
 
+from pgmax.factors.enumeration import EnumerationFactor
 from pgmax.fg import graph
 from pgmax.groups import logical
 from pgmax.groups import variables as vgroup
@@ -94,26 +95,29 @@ def test_run_bp_with_ANDFactors():
 
             if factor_idx < num_factors // 2:
                 # Add the first half of factors to FactorGraph1
-                fg1.add_factor(
+                enum_factor = EnumerationFactor(
                     variables=variables_for_factors1[factor_idx],
                     factor_configs=valid_configs,
                     log_potentials=np.zeros(valid_configs.shape[0]),
                 )
+                fg1.add_factor(enum_factor)
             else:
                 if idx != 0:
                     # Add the second half of factors to FactorGraph2
-                    fg2.add_factor(
+                    enum_factor = EnumerationFactor(
                         variables=variables_for_factors2[factor_idx],
                         factor_configs=valid_configs,
                         log_potentials=np.zeros(valid_configs.shape[0]),
                     )
+                    fg2.add_factor(enum_factor)
                 else:
                     # Add all the EnumerationFactors to FactorGraph1 for the first iter
-                    fg1.add_factor(
+                    enum_factor = EnumerationFactor(
                         variables=variables_for_factors1[factor_idx],
                         factor_configs=valid_configs,
                         log_potentials=np.zeros(valid_configs.shape[0]),
                     )
+                    fg1.add_factor(enum_factor)
 
         # Option 2: Define the ANDFactors
         num_parents_cumsum = np.insert(np.cumsum(num_parents), 0, 0)
@@ -136,14 +140,11 @@ def test_run_bp_with_ANDFactors():
                         variables_for_factors2[factor_idx]
                     )
         if idx != 0:
-            fg1.add_factor_group(
-                factory=logical.ANDFactorGroup,
-                variables_for_factors=variables_for_ANDFactors_fg1,
-            )
-        fg2.add_factor_group(
-            factory=logical.ANDFactorGroup,
-            variables_for_factors=variables_for_ANDFactors_fg2,
-        )
+            factor_group = logical.ANDFactorGroup(variables_for_ANDFactors_fg1)
+            fg1.add_factor_group(factor_group)
+
+        factor_group = logical.ANDFactorGroup(variables_for_ANDFactors_fg2)
+        fg2.add_factor_group(factor_group)
 
         # Run inference
         bp1 = graph.BP(fg1.bp_state, temperature=temperature)

--- a/tests/factors/test_and.py
+++ b/tests/factors/test_and.py
@@ -104,7 +104,7 @@ def test_run_bp_with_ANDFactors():
                     factor_configs=valid_configs,
                     log_potentials=np.zeros(valid_configs.shape[0]),
                 )
-                fg1.add_factors(factor=enum_factor)
+                fg1.add_factors(enum_factor)
             else:
                 if idx != 0:
                     # Add the second half of factors to FactorGraph2
@@ -113,7 +113,7 @@ def test_run_bp_with_ANDFactors():
                         factor_configs=valid_configs,
                         log_potentials=np.zeros(valid_configs.shape[0]),
                     )
-                    fg2.add_factors(factor=enum_factor)
+                    fg2.add_factors(enum_factor)
                 else:
                     # Add all the EnumerationFactors to FactorGraph1 for the first iter
                     enum_factor = EnumerationFactor(
@@ -121,7 +121,7 @@ def test_run_bp_with_ANDFactors():
                         factor_configs=valid_configs,
                         log_potentials=np.zeros(valid_configs.shape[0]),
                     )
-                    fg1.add_factors(factor=enum_factor)
+                    fg1.add_factors(enum_factor)
 
         # Option 2: Define the ANDFactors
         num_parents_cumsum = np.insert(np.cumsum(num_parents), 0, 0)

--- a/tests/factors/test_or.py
+++ b/tests/factors/test_or.py
@@ -58,23 +58,23 @@ def test_run_bp_with_ORFactors():
         variables_for_factors1 = []
         variables_for_factors2 = []
         for factor_idx in range(num_factors):
-            variable_names1 = [
+            variables1 = [
                 parents_variables1[idx]
                 for idx in range(
                     num_parents_cumsum[factor_idx],
                     num_parents_cumsum[factor_idx + 1],
                 )
             ] + [children_variables1[factor_idx]]
-            variables_for_factors1.append(variable_names1)
+            variables_for_factors1.append(variables1)
 
-            variable_names2 = [
+            variables2 = [
                 parents_variables2[idx]
                 for idx in range(
                     num_parents_cumsum[factor_idx],
                     num_parents_cumsum[factor_idx + 1],
                 )
             ] + [children_variables2[factor_idx]]
-            variables_for_factors2.append(variable_names2)
+            variables_for_factors2.append(variables2)
 
         # Option 1: Define EnumerationFactors equivalent to the ORFactors
         for factor_idx in range(num_factors):
@@ -94,7 +94,7 @@ def test_run_bp_with_ORFactors():
             if factor_idx < num_factors // 2:
                 # Add the first half of factors to FactorGraph1
                 fg1.add_factor(
-                    variable_names=variables_for_factors1[factor_idx],
+                    variables=variables_for_factors1[factor_idx],
                     factor_configs=valid_configs,
                     log_potentials=np.zeros(valid_configs.shape[0]),
                 )
@@ -102,14 +102,14 @@ def test_run_bp_with_ORFactors():
                 if idx != 0:
                     # Add the second half of factors to FactorGraph2
                     fg2.add_factor(
-                        variable_names=variables_for_factors2[factor_idx],
+                        variables=variables_for_factors2[factor_idx],
                         factor_configs=valid_configs,
                         log_potentials=np.zeros(valid_configs.shape[0]),
                     )
                 else:
                     # Add all the EnumerationFactors to FactorGraph1 for the first iter
                     fg1.add_factor(
-                        variable_names=variables_for_factors1[factor_idx],
+                        variables=variables_for_factors1[factor_idx],
                         factor_configs=valid_configs,
                         log_potentials=np.zeros(valid_configs.shape[0]),
                     )

--- a/tests/factors/test_or.py
+++ b/tests/factors/test_or.py
@@ -8,7 +8,7 @@ from pgmax.groups import logical
 from pgmax.groups import variables as vgroup
 
 
-def test_run_bp_with_OR_factors():
+def test_run_bp_with_ORFactors():
     """
     Simultaneously test
     (1) the support of ORFactors in a FactorGraph and their specialized inference for different temperatures
@@ -55,8 +55,8 @@ def test_run_bp_with_OR_factors():
         fg2 = graph.FactorGraph(variables=[parents_variables2, children_variables2])
 
         # Variable names for factors
-        variable_names_for_factors1 = []
-        variable_names_for_factors2 = []
+        variables_for_factors1 = []
+        variables_for_factors2 = []
         for factor_idx in range(num_factors):
             variable_names1 = [
                 parents_variables1[idx]
@@ -65,7 +65,7 @@ def test_run_bp_with_OR_factors():
                     num_parents_cumsum[factor_idx + 1],
                 )
             ] + [children_variables1[factor_idx]]
-            variable_names_for_factors1.append(variable_names1)
+            variables_for_factors1.append(variable_names1)
 
             variable_names2 = [
                 parents_variables2[idx]
@@ -74,7 +74,7 @@ def test_run_bp_with_OR_factors():
                     num_parents_cumsum[factor_idx + 1],
                 )
             ] + [children_variables2[factor_idx]]
-            variable_names_for_factors2.append(variable_names2)
+            variables_for_factors2.append(variable_names2)
 
         # Option 1: Define EnumerationFactors equivalent to the ORFactors
         for factor_idx in range(num_factors):
@@ -94,7 +94,7 @@ def test_run_bp_with_OR_factors():
             if factor_idx < num_factors // 2:
                 # Add the first half of factors to FactorGraph1
                 fg1.add_factor(
-                    variable_names=variable_names_for_factors1[factor_idx],
+                    variable_names=variables_for_factors1[factor_idx],
                     factor_configs=valid_configs,
                     log_potentials=np.zeros(valid_configs.shape[0]),
                 )
@@ -102,48 +102,46 @@ def test_run_bp_with_OR_factors():
                 if idx != 0:
                     # Add the second half of factors to FactorGraph2
                     fg2.add_factor(
-                        variable_names=variable_names_for_factors2[factor_idx],
+                        variable_names=variables_for_factors2[factor_idx],
                         factor_configs=valid_configs,
                         log_potentials=np.zeros(valid_configs.shape[0]),
                     )
                 else:
                     # Add all the EnumerationFactors to FactorGraph1 for the first iter
                     fg1.add_factor(
-                        variable_names=variable_names_for_factors1[factor_idx],
+                        variable_names=variables_for_factors1[factor_idx],
                         factor_configs=valid_configs,
                         log_potentials=np.zeros(valid_configs.shape[0]),
                     )
 
         # Option 2: Define the ORFactors
         num_parents_cumsum = np.insert(np.cumsum(num_parents), 0, 0)
-        variable_names_for_ORFactors_fg1 = []
-        variable_names_for_ORFactors_fg2 = []
+        variables_for_ORFactors_fg1 = []
+        variables_for_ORFactors_fg2 = []
 
         for factor_idx in range(num_factors):
             if factor_idx < num_factors // 2:
                 # Add the first half of factors to FactorGraph2
-                variable_names_for_ORFactors_fg2.append(
-                    variable_names_for_factors2[factor_idx]
-                )
+                variables_for_ORFactors_fg2.append(variables_for_factors2[factor_idx])
             else:
                 if idx != 0:
                     # Add the second half of factors to FactorGraph1
-                    variable_names_for_ORFactors_fg1.append(
-                        variable_names_for_factors1[factor_idx]
+                    variables_for_ORFactors_fg1.append(
+                        variables_for_factors1[factor_idx]
                     )
                 else:
                     # Add all the ORFactors to FactorGraph2 for the first iter
-                    variable_names_for_ORFactors_fg2.append(
-                        variable_names_for_factors2[factor_idx]
+                    variables_for_ORFactors_fg2.append(
+                        variables_for_factors2[factor_idx]
                     )
         if idx != 0:
             fg1.add_factor_group(
                 factory=logical.ORFactorGroup,
-                variable_names_for_factors=variable_names_for_ORFactors_fg1,
+                variables_for_factors=variables_for_ORFactors_fg1,
             )
         fg2.add_factor_group(
             factory=logical.ORFactorGroup,
-            variable_names_for_factors=variable_names_for_ORFactors_fg2,
+            variables_for_factors=variables_for_ORFactors_fg2,
         )
 
         # Run inference
@@ -168,8 +166,8 @@ def test_run_bp_with_OR_factors():
         bp_arrays2 = bp2.run_bp(bp_arrays2, num_iters=5)
 
         # Get beliefs
-        beliefs1 = bp1.get_bp_output(bp_arrays1).beliefs
-        beliefs2 = bp2.get_bp_output(bp_arrays2).beliefs
+        beliefs1 = bp1.get_beliefs(bp_arrays1)
+        beliefs2 = bp2.get_beliefs(bp_arrays2)
 
         assert np.allclose(
             beliefs1[children_variables1], beliefs2[children_variables2], atol=1e-4

--- a/tests/factors/test_or.py
+++ b/tests/factors/test_or.py
@@ -102,7 +102,7 @@ def test_run_bp_with_ORFactors():
                     factor_configs=valid_configs,
                     log_potentials=np.zeros(valid_configs.shape[0]),
                 )
-                fg1.add_factor(factor=enum_factor)
+                fg1.add_factors(factor=enum_factor)
             else:
                 if idx != 0:
                     # Add the second half of factors to FactorGraph2
@@ -111,7 +111,7 @@ def test_run_bp_with_ORFactors():
                         factor_configs=valid_configs,
                         log_potentials=np.zeros(valid_configs.shape[0]),
                     )
-                    fg2.add_factor(factor=enum_factor)
+                    fg2.add_factors(factor=enum_factor)
                 else:
                     # Add all the EnumerationFactors to FactorGraph1 for the first iter
                     enum_factor = EnumerationFactor(
@@ -119,7 +119,7 @@ def test_run_bp_with_ORFactors():
                         factor_configs=valid_configs,
                         log_potentials=np.zeros(valid_configs.shape[0]),
                     )
-                    fg1.add_factor(factor=enum_factor)
+                    fg1.add_factors(factor=enum_factor)
 
         # Option 2: Define the ORFactors
         num_parents_cumsum = np.insert(np.cumsum(num_parents), 0, 0)
@@ -143,10 +143,10 @@ def test_run_bp_with_ORFactors():
                     )
         if idx != 0:
             factor_group = logical.ORFactorGroup(variables_for_ORFactors_fg1)
-            fg1.add_factor_group(factor_group)
+            fg1.add_factors(factor_group)
 
         factor_group = logical.ORFactorGroup(variables_for_ORFactors_fg2)
-        fg2.add_factor_group(factor_group)
+        fg2.add_factors(factor_group)
 
         # Run inference
         bp1 = graph.BP(fg1.bp_state, temperature=temperature)

--- a/tests/factors/test_or.py
+++ b/tests/factors/test_or.py
@@ -25,6 +25,7 @@ def test_run_bp_with_OR_factors():
     Note: for the first seed, add all the EnumerationFactors to FG1 and all the ORFactors to FG2
     """
     for idx in range(10):
+        print("it", idx)
         np.random.seed(idx)
 
         # Parameters
@@ -43,30 +44,41 @@ def test_run_bp_with_OR_factors():
         parents_variables1 = vgroup.NDVariableArray(
             num_states=2, shape=(num_parents.sum(),)
         )
-        children_variable1 = vgroup.NDVariableArray(num_states=2, shape=(num_factors,))
-        fg1 = graph.FactorGraph(
-            variables=dict(parents=parents_variables1, children=children_variable1)
-        )
+        children_variables1 = vgroup.NDVariableArray(num_states=2, shape=(num_factors,))
+        fg1 = graph.FactorGraph(variables=[parents_variables1, children_variables1])
 
         # Graph 2
         parents_variables2 = vgroup.NDVariableArray(
             num_states=2, shape=(num_parents.sum(),)
         )
-        children_variable2 = vgroup.NDVariableArray(num_states=2, shape=(num_factors,))
-        fg2 = graph.FactorGraph(
-            variables=dict(parents=parents_variables2, children=children_variable2)
-        )
+        children_variables2 = vgroup.NDVariableArray(num_states=2, shape=(num_factors,))
+        fg2 = graph.FactorGraph(variables=[parents_variables2, children_variables2])
 
-        # Option 1: Define EnumerationFactors equivalent to the ORFactors
+        # Variable names for factors
+        variable_names_for_factors1 = []
+        variable_names_for_factors2 = []
         for factor_idx in range(num_factors):
-            this_num_parents = num_parents[factor_idx]
-            variable_names = [
-                ("parents", idx)
+            variable_names1 = [
+                parents_variables1[idx]
                 for idx in range(
                     num_parents_cumsum[factor_idx],
                     num_parents_cumsum[factor_idx + 1],
                 )
-            ] + [("children", factor_idx)]
+            ] + [children_variables1[factor_idx]]
+            variable_names_for_factors1.append(variable_names1)
+
+            variable_names2 = [
+                parents_variables2[idx]
+                for idx in range(
+                    num_parents_cumsum[factor_idx],
+                    num_parents_cumsum[factor_idx + 1],
+                )
+            ] + [children_variables2[factor_idx]]
+            variable_names_for_factors2.append(variable_names2)
+
+        # Option 1: Define EnumerationFactors equivalent to the ORFactors
+        for factor_idx in range(num_factors):
+            this_num_parents = num_parents[factor_idx]
 
             configs = np.array(list(product([0, 1], repeat=this_num_parents + 1)))
             # Children state is last
@@ -82,7 +94,7 @@ def test_run_bp_with_OR_factors():
             if factor_idx < num_factors // 2:
                 # Add the first half of factors to FactorGraph1
                 fg1.add_factor(
-                    variable_names=variable_names,
+                    variable_names=variable_names_for_factors1[factor_idx],
                     factor_configs=valid_configs,
                     log_potentials=np.zeros(valid_configs.shape[0]),
                 )
@@ -90,14 +102,14 @@ def test_run_bp_with_OR_factors():
                 if idx != 0:
                     # Add the second half of factors to FactorGraph2
                     fg2.add_factor(
-                        variable_names=variable_names,
+                        variable_names=variable_names_for_factors2[factor_idx],
                         factor_configs=valid_configs,
                         log_potentials=np.zeros(valid_configs.shape[0]),
                     )
                 else:
                     # Add all the EnumerationFactors to FactorGraph1 for the first iter
                     fg1.add_factor(
-                        variable_names=variable_names,
+                        variable_names=variable_names_for_factors1[factor_idx],
                         factor_configs=valid_configs,
                         log_potentials=np.zeros(valid_configs.shape[0]),
                     )
@@ -108,28 +120,22 @@ def test_run_bp_with_OR_factors():
         variable_names_for_ORFactors_fg2 = []
 
         for factor_idx in range(num_factors):
-            variables_names_for_ORFactor = [
-                ("parents", idx)
-                for idx in range(
-                    num_parents_cumsum[factor_idx],
-                    num_parents_cumsum[factor_idx + 1],
-                )
-            ] + [("children", factor_idx)]
             if factor_idx < num_factors // 2:
                 # Add the first half of factors to FactorGraph2
-                variable_names_for_ORFactors_fg2.append(variables_names_for_ORFactor)
+                variable_names_for_ORFactors_fg2.append(
+                    variable_names_for_factors2[factor_idx]
+                )
             else:
                 if idx != 0:
                     # Add the second half of factors to FactorGraph1
                     variable_names_for_ORFactors_fg1.append(
-                        variables_names_for_ORFactor
+                        variable_names_for_factors1[factor_idx]
                     )
                 else:
                     # Add all the ORFactors to FactorGraph2 for the first iter
                     variable_names_for_ORFactors_fg2.append(
-                        variables_names_for_ORFactor
+                        variable_names_for_factors2[factor_idx]
                     )
-
         if idx != 0:
             fg1.add_factor_group(
                 factory=logical.ORFactorGroup,
@@ -144,19 +150,30 @@ def test_run_bp_with_OR_factors():
         bp1 = graph.BP(fg1.bp_state, temperature=temperature)
         bp2 = graph.BP(fg2.bp_state, temperature=temperature)
 
-        evidence_updates = {
-            "parents": jax.device_put(np.random.gumbel(size=(sum(num_parents), 2))),
-            "children": jax.device_put(np.random.gumbel(size=(num_factors, 2))),
+        evidence_parents = jax.device_put(np.random.gumbel(size=(sum(num_parents), 2)))
+        evidence_children = jax.device_put(np.random.gumbel(size=(num_factors, 2)))
+
+        evidence_updates1 = {
+            parents_variables1: evidence_parents,
+            children_variables1: evidence_children,
+        }
+        evidence_updates2 = {
+            parents_variables2: evidence_parents,
+            children_variables2: evidence_children,
         }
 
-        bp_arrays1 = bp1.init(evidence_updates=evidence_updates)
+        bp_arrays1 = bp1.init(evidence_updates=evidence_updates1)
         bp_arrays1 = bp1.run_bp(bp_arrays1, num_iters=5)
-        bp_arrays2 = bp2.init(evidence_updates=evidence_updates)
+        bp_arrays2 = bp2.init(evidence_updates=evidence_updates2)
         bp_arrays2 = bp2.run_bp(bp_arrays2, num_iters=5)
 
         # Get beliefs
-        beliefs1 = bp1.get_beliefs(bp_arrays1)
-        beliefs2 = bp2.get_beliefs(bp_arrays2)
+        beliefs1 = bp1.get_bp_output(bp_arrays1).beliefs
+        beliefs2 = bp2.get_bp_output(bp_arrays2).beliefs
 
-        assert np.allclose(beliefs1["children"], beliefs2["children"], atol=1e-4)
-        assert np.allclose(beliefs1["parents"], beliefs2["parents"], atol=1e-4)
+        assert np.allclose(
+            beliefs1[children_variables1], beliefs2[children_variables2], atol=1e-4
+        )
+        assert np.allclose(
+            beliefs1[parents_variables1], beliefs2[parents_variables2], atol=1e-4
+        )

--- a/tests/factors/test_or.py
+++ b/tests/factors/test_or.py
@@ -3,6 +3,7 @@ from itertools import product
 import jax
 import numpy as np
 
+from pgmax.factors.enumeration import EnumerationFactor
 from pgmax.fg import graph
 from pgmax.groups import logical
 from pgmax.groups import variables as vgroup
@@ -92,26 +93,29 @@ def test_run_bp_with_ORFactors():
 
             if factor_idx < num_factors // 2:
                 # Add the first half of factors to FactorGraph1
-                fg1.add_factor(
+                enum_factor = EnumerationFactor(
                     variables=variables_for_factors1[factor_idx],
                     factor_configs=valid_configs,
                     log_potentials=np.zeros(valid_configs.shape[0]),
                 )
+                fg1.add_factor(enum_factor)
             else:
                 if idx != 0:
                     # Add the second half of factors to FactorGraph2
-                    fg2.add_factor(
+                    enum_factor = EnumerationFactor(
                         variables=variables_for_factors2[factor_idx],
                         factor_configs=valid_configs,
                         log_potentials=np.zeros(valid_configs.shape[0]),
                     )
+                    fg2.add_factor(enum_factor)
                 else:
                     # Add all the EnumerationFactors to FactorGraph1 for the first iter
-                    fg1.add_factor(
+                    enum_factor = EnumerationFactor(
                         variables=variables_for_factors1[factor_idx],
                         factor_configs=valid_configs,
                         log_potentials=np.zeros(valid_configs.shape[0]),
                     )
+                    fg1.add_factor(enum_factor)
 
         # Option 2: Define the ORFactors
         num_parents_cumsum = np.insert(np.cumsum(num_parents), 0, 0)
@@ -134,14 +138,11 @@ def test_run_bp_with_ORFactors():
                         variables_for_factors2[factor_idx]
                     )
         if idx != 0:
-            fg1.add_factor_group(
-                factory=logical.ORFactorGroup,
-                variables_for_factors=variables_for_ORFactors_fg1,
-            )
-        fg2.add_factor_group(
-            factory=logical.ORFactorGroup,
-            variables_for_factors=variables_for_ORFactors_fg2,
-        )
+            factor_group = logical.ORFactorGroup(variables_for_ORFactors_fg1)
+            fg1.add_factor_group(factor_group)
+
+        factor_group = logical.ORFactorGroup(variables_for_ORFactors_fg2)
+        fg2.add_factor_group(factor_group)
 
         # Run inference
         bp1 = graph.BP(fg1.bp_state, temperature=temperature)

--- a/tests/factors/test_or.py
+++ b/tests/factors/test_or.py
@@ -102,7 +102,7 @@ def test_run_bp_with_ORFactors():
                     factor_configs=valid_configs,
                     log_potentials=np.zeros(valid_configs.shape[0]),
                 )
-                fg1.add_factors(factor=enum_factor)
+                fg1.add_factors(enum_factor)
             else:
                 if idx != 0:
                     # Add the second half of factors to FactorGraph2
@@ -111,7 +111,7 @@ def test_run_bp_with_ORFactors():
                         factor_configs=valid_configs,
                         log_potentials=np.zeros(valid_configs.shape[0]),
                     )
-                    fg2.add_factors(factor=enum_factor)
+                    fg2.add_factors(enum_factor)
                 else:
                     # Add all the EnumerationFactors to FactorGraph1 for the first iter
                     enum_factor = EnumerationFactor(
@@ -119,7 +119,7 @@ def test_run_bp_with_ORFactors():
                         factor_configs=valid_configs,
                         log_potentials=np.zeros(valid_configs.shape[0]),
                     )
-                    fg1.add_factors(factor=enum_factor)
+                    fg1.add_factors(enum_factor)
 
         # Option 2: Define the ORFactors
         num_parents_cumsum = np.insert(np.cumsum(num_parents), 0, 0)

--- a/tests/factors/test_or.py
+++ b/tests/factors/test_or.py
@@ -25,7 +25,6 @@ def test_run_bp_with_ORFactors():
     Note: for the first seed, add all the EnumerationFactors to FG1 and all the ORFactors to FG2
     """
     for idx in range(10):
-        print("it", idx)
         np.random.seed(idx)
 
         # Parameters

--- a/tests/factors/test_or.py
+++ b/tests/factors/test_or.py
@@ -45,14 +45,18 @@ def test_run_bp_with_ORFactors():
             num_states=2, shape=(num_parents.sum(),)
         )
         children_variables1 = vgroup.NDVariableArray(num_states=2, shape=(num_factors,))
-        fg1 = graph.FactorGraph(variables=[parents_variables1, children_variables1])
+        fg1 = graph.FactorGraph(
+            variable_groups=[parents_variables1, children_variables1]
+        )
 
         # Graph 2
         parents_variables2 = vgroup.NDVariableArray(
             num_states=2, shape=(num_parents.sum(),)
         )
         children_variables2 = vgroup.NDVariableArray(num_states=2, shape=(num_factors,))
-        fg2 = graph.FactorGraph(variables=[parents_variables2, children_variables2])
+        fg2 = graph.FactorGraph(
+            variable_groups=[parents_variables2, children_variables2]
+        )
 
         # Variable names for factors
         variables_for_factors1 = []
@@ -98,7 +102,7 @@ def test_run_bp_with_ORFactors():
                     factor_configs=valid_configs,
                     log_potentials=np.zeros(valid_configs.shape[0]),
                 )
-                fg1.add_factor(enum_factor)
+                fg1.add_factor(factor=enum_factor)
             else:
                 if idx != 0:
                     # Add the second half of factors to FactorGraph2
@@ -107,7 +111,7 @@ def test_run_bp_with_ORFactors():
                         factor_configs=valid_configs,
                         log_potentials=np.zeros(valid_configs.shape[0]),
                     )
-                    fg2.add_factor(enum_factor)
+                    fg2.add_factor(factor=enum_factor)
                 else:
                     # Add all the EnumerationFactors to FactorGraph1 for the first iter
                     enum_factor = EnumerationFactor(
@@ -115,7 +119,7 @@ def test_run_bp_with_ORFactors():
                         factor_configs=valid_configs,
                         log_potentials=np.zeros(valid_configs.shape[0]),
                     )
-                    fg1.add_factor(enum_factor)
+                    fg1.add_factor(factor=enum_factor)
 
         # Option 2: Define the ORFactors
         num_parents_cumsum = np.insert(np.cumsum(num_parents), 0, 0)

--- a/tests/fg/test_graph.py
+++ b/tests/fg/test_graph.py
@@ -13,7 +13,7 @@ from pgmax.groups import variables as vgroup
 
 
 def test_factor_graph():
-    vg = vgroup.VariableDict(15, (0,))
+    vg = vgroup.VariableDict(variable_names=(0,), num_states=15)
     fg = graph.FactorGraph(vg)
     fg.add_factor_by_type(
         factor_type=enumeration_factor.EnumerationFactor,
@@ -76,7 +76,7 @@ def test_factor_adding():
 
 
 def test_bp_state():
-    vg = vgroup.VariableDict(15, (0,))
+    vg = vgroup.VariableDict(variable_names=(0,), num_states=15)
     fg0 = graph.FactorGraph(vg)
     fg0.add_factor(
         variables=[vg[0]],
@@ -101,7 +101,7 @@ def test_bp_state():
 
 
 def test_log_potentials():
-    vg = vgroup.VariableDict(15, (0,))
+    vg = vgroup.VariableDict(variable_names=(0,), num_states=15)
     fg = graph.FactorGraph(vg)
     fg.add_factor(
         variables=[vg[0]],
@@ -130,7 +130,7 @@ def test_log_potentials():
 
 
 def test_ftov_msgs():
-    vg = vgroup.VariableDict(15, (0,))
+    vg = vgroup.VariableDict(variable_names=(0,), num_states=15)
     fg = graph.FactorGraph(vg)
     fg.add_factor(
         variables=[vg[0]],
@@ -164,7 +164,7 @@ def test_ftov_msgs():
 
 
 def test_evidence():
-    vg = vgroup.VariableDict(15, (0,))
+    vg = vgroup.VariableDict(variable_names=(0,), num_states=15)
     fg = graph.FactorGraph(vg)
     fg.add_factor(
         variables=[vg[0]],
@@ -181,7 +181,7 @@ def test_evidence():
 
 
 def test_bp():
-    vg = vgroup.VariableDict(15, (0,))
+    vg = vgroup.VariableDict(variable_names=(0,), num_states=15)
     fg = graph.FactorGraph(vg)
     fg.add_factor(
         variables=[vg[0]],

--- a/tests/fg/test_graph.py
+++ b/tests/fg/test_graph.py
@@ -5,10 +5,9 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
-from pgmax.factors import FAC_TO_VAR_UPDATES
 from pgmax.factors import enumeration as enumeration_factor
 from pgmax.fg import graph, groups
-from pgmax.groups import logical
+from pgmax.groups import enumeration, logical
 from pgmax.groups import variables as vgroup
 
 
@@ -39,13 +38,12 @@ def test_factor_graph():
         fg.add_factor(factor)
 
 
-def test_factor_adding():
+def test_single_factor():
+    with pytest.raises(ValueError, match="Cannot create a FactorGroup with no Factor."):
+        logical.ORFactorGroup(variables_for_factors=[])
+
     A = vgroup.NDVariableArray(num_states=2, shape=(10,))
     B = vgroup.NDVariableArray(num_states=2, shape=(10,))
-    fg = graph.FactorGraph(variables=[A, B])
-
-    with pytest.raises(ValueError, match="Cannot create a FactorGroup with no Factor."):
-        factor_group = logical.ORFactorGroup(variables_for_factors=[])
 
     variables0 = (A[0], B[0])
     variables1 = (A[1], B[1])
@@ -86,100 +84,102 @@ def test_bp_state():
 def test_log_potentials():
     vg = vgroup.VariableDict(variable_names=(0,), num_states=15)
     fg = graph.FactorGraph(vg)
-    factor = enumeration_factor.EnumerationFactor(
-        variables=[vg[0]],
-        factor_configs=np.arange(15)[:, None],
-        log_potentials=np.zeros(15),
+    factor_group = enumeration.EnumerationFactorGroup(
+        variables_for_factors=[[vg[0]]],
+        factor_configs=np.arange(10)[:, None],
     )
-    fg.add_factor(factor, name="test")
+    fg.add_factor_group(factor_group, name="test")
 
-    # with pytest.raises(
-    #     ValueError,
-    #     match=re.escape("Expected log potentials shape (10,) for factor group test."),
-    # ):
-    #     fg.bp_state.log_potentials["test"] = jnp.zeros((1, 15))
+    with pytest.raises(
+        ValueError,
+        match=re.escape("Expected log potentials shape (10,) for factor group test."),
+    ):
+        fg.bp_state.log_potentials["test"] = jnp.zeros((1, 15))
 
-    # with pytest.raises(
-    #     ValueError,
-    #     match=re.escape("Invalid name (0, 15) for log potentials updates."),
-    # ):
-    #     fg.bp_state.log_potentials[vg[0]] = np.zeros(10)
+    with pytest.raises(
+        ValueError,
+        match=re.escape("Invalid name (0, 15) for log potentials updates."),
+    ):
+        fg.bp_state.log_potentials[vg[0]] = np.zeros(10)
 
-    # with pytest.raises(
-    #     ValueError, match=re.escape("Expected log potentials shape (10,). Got (15,)")
-    # ):
-    #     graph.LogPotentials(fg_state=fg.fg_state, value=np.zeros(15))
+    with pytest.raises(
+        ValueError, match=re.escape("Expected log potentials shape (10,). Got (15,)")
+    ):
+        graph.LogPotentials(fg_state=fg.fg_state, value=np.zeros(15))
 
-    # log_potentials = graph.LogPotentials(fg_state=fg.fg_state, value=np.zeros(10))
-    # assert jnp.all(log_potentials["test"] == jnp.zeros(10))
-
-
-# def test_ftov_msgs():
-#     vg = vgroup.VariableDict(variable_names=(0,), num_states=15)
-#     fg = graph.FactorGraph(vg)
-#     fg.add_factor(
-#         variables=[vg[0]],
-#         factor_configs=np.arange(10)[:, None],
-#         name="test",
-#     )
-#     with pytest.raises(
-#         ValueError,
-#         match=re.escape("Invalid names for setting messages"),
-#     ):
-#         fg.bp_state.ftov_msgs[0] = np.ones(10)
-
-#     with pytest.raises(
-#         ValueError,
-#         match=re.escape(
-#             "Given belief shape (10,) does not match expected shape (15,) for variable (0, 15)."
-#         ),
-#     ):
-#         fg.bp_state.ftov_msgs[vg[0]] = np.ones(10)
-
-#     with pytest.raises(
-#         ValueError, match=re.escape("Expected messages shape (15,). Got (10,)")
-#     ):
-#         graph.FToVMessages(fg_state=fg.fg_state, value=np.zeros(10))
-
-#     ftov_msgs = graph.FToVMessages(fg_state=fg.fg_state, value=np.zeros(15))
-#     with pytest.raises(
-#         TypeError, match=re.escape("'FToVMessages' object is not subscriptable")
-#     ):
-#         ftov_msgs[(10,)]
+    log_potentials = graph.LogPotentials(fg_state=fg.fg_state, value=np.zeros(10))
+    assert jnp.all(log_potentials["test"] == jnp.zeros(10))
 
 
-# def test_evidence():
-#     vg = vgroup.VariableDict(variable_names=(0,), num_states=15)
-#     fg = graph.FactorGraph(vg)
-#     fg.add_factor(
-#         variables=[vg[0]],
-#         factor_configs=np.arange(10)[:, None],
-#         name="test",
-#     )
-#     with pytest.raises(
-#         ValueError, match=re.escape("Expected evidence shape (15,). Got (10,).")
-#     ):
-#         graph.Evidence(fg_state=fg.fg_state, value=np.zeros(10))
+def test_ftov_msgs():
+    vg = vgroup.VariableDict(variable_names=(0,), num_states=15)
+    fg = graph.FactorGraph(vg)
+    factor_group = enumeration.EnumerationFactorGroup(
+        variables_for_factors=[[vg[0]]],
+        factor_configs=np.arange(10)[:, None],
+    )
+    fg.add_factor_group(factor_group, name="test")
 
-#     evidence = graph.Evidence(fg_state=fg.fg_state, value=np.zeros(15))
-#     assert jnp.all(evidence.value == jnp.zeros(15))
+    with pytest.raises(
+        ValueError,
+        match=re.escape("Invalid names for setting messages"),
+    ):
+        fg.bp_state.ftov_msgs[0] = np.ones(10)
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "Given belief shape (10,) does not match expected shape (15,) for variable (0, 15)."
+        ),
+    ):
+        fg.bp_state.ftov_msgs[vg[0]] = np.ones(10)
+
+    with pytest.raises(
+        ValueError, match=re.escape("Expected messages shape (15,). Got (10,)")
+    ):
+        graph.FToVMessages(fg_state=fg.fg_state, value=np.zeros(10))
+
+    ftov_msgs = graph.FToVMessages(fg_state=fg.fg_state, value=np.zeros(15))
+    with pytest.raises(
+        TypeError, match=re.escape("'FToVMessages' object is not subscriptable")
+    ):
+        ftov_msgs[(10,)]
 
 
-# def test_bp():
-#     vg = vgroup.VariableDict(variable_names=(0,), num_states=15)
-#     fg = graph.FactorGraph(vg)
-#     fg.add_factor(
-#         variables=[vg[0]],
-#         factor_configs=np.arange(10)[:, None],
-#         name="test",
-#     )
-#     bp = graph.BP(fg.bp_state, temperature=0)
-#     bp_arrays = bp.update()
-#     bp_arrays = bp.update(
-#         bp_arrays=bp_arrays,
-#         ftov_msgs_updates={vg[0]: np.zeros(15)},
-#     )
-#     bp_arrays = bp.run_bp(bp_arrays, num_iters=1)
-#     bp_arrays = replace(bp_arrays, log_potentials=jnp.zeros((10)))
-#     bp_state = bp.to_bp_state(bp_arrays)
-#     assert bp_state.fg_state == fg.fg_state
+def test_evidence():
+    vg = vgroup.VariableDict(variable_names=(0,), num_states=15)
+    fg = graph.FactorGraph(vg)
+    factor_group = enumeration.EnumerationFactorGroup(
+        variables_for_factors=[[vg[0]]],
+        factor_configs=np.arange(10)[:, None],
+    )
+    fg.add_factor_group(factor_group, name="test")
+
+    with pytest.raises(
+        ValueError, match=re.escape("Expected evidence shape (15,). Got (10,).")
+    ):
+        graph.Evidence(fg_state=fg.fg_state, value=np.zeros(10))
+
+    evidence = graph.Evidence(fg_state=fg.fg_state, value=np.zeros(15))
+    assert jnp.all(evidence.value == jnp.zeros(15))
+
+
+def test_bp():
+    vg = vgroup.VariableDict(variable_names=(0,), num_states=15)
+    fg = graph.FactorGraph(vg)
+    factor_group = enumeration.EnumerationFactorGroup(
+        variables_for_factors=[[vg[0]]],
+        factor_configs=np.arange(10)[:, None],
+    )
+    fg.add_factor_group(factor_group, name="test")
+
+    bp = graph.BP(fg.bp_state, temperature=0)
+    bp_arrays = bp.update()
+    bp_arrays = bp.update(
+        bp_arrays=bp_arrays,
+        ftov_msgs_updates={vg[0]: np.zeros(15)},
+    )
+    bp_arrays = bp.run_bp(bp_arrays, num_iters=1)
+    bp_arrays = replace(bp_arrays, log_potentials=jnp.zeros((10)))
+    bp_state = bp.to_bp_state(bp_arrays)
+    assert bp_state.fg_state == fg.fg_state

--- a/tests/fg/test_graph.py
+++ b/tests/fg/test_graph.py
@@ -100,72 +100,67 @@ def test_bp_state():
         )
 
 
-# def test_log_potentials():
-#     vg = vgroup.VariableDict(15, (0,))
-#     fg = graph.FactorGraph(vg)
-#     fg.add_factor(
-#         variables=[vg[0]],
-#         factor_configs=np.arange(10)[:, None],
-#         name="test",
-#     )
-#     with pytest.raises(
-#         ValueError,
-#         match=re.escape("Expected log potentials shape (10,) for factor group test."),
-#     ):
-#         fg.bp_state.log_potentials["test"] = jnp.zeros((1, 15))
+def test_log_potentials():
+    vg = vgroup.VariableDict(15, (0,))
+    fg = graph.FactorGraph(vg)
+    fg.add_factor(
+        variables=[vg[0]],
+        factor_configs=np.arange(10)[:, None],
+        name="test",
+    )
+    with pytest.raises(
+        ValueError,
+        match=re.escape("Expected log potentials shape (10,) for factor group test."),
+    ):
+        fg.bp_state.log_potentials["test"] = jnp.zeros((1, 15))
 
-#     with pytest.raises(
-#         ValueError,
-#         match=re.escape(f"Invalid name {frozenset([0])} for log potentials updates."),
-#     ):
-#         fg.bp_state.log_potentials[vg[0]] = np.zeros(10)
+    with pytest.raises(
+        ValueError,
+        match=re.escape("Invalid name (0, 15) for log potentials updates."),
+    ):
+        fg.bp_state.log_potentials[vg[0]] = np.zeros(10)
 
-#     with pytest.raises(
-#         ValueError, match=re.escape("Expected log potentials shape (10,). Got (15,)")
-#     ):
-#         graph.LogPotentials(fg_state=fg.fg_state, value=np.zeros(15))
+    with pytest.raises(
+        ValueError, match=re.escape("Expected log potentials shape (10,). Got (15,)")
+    ):
+        graph.LogPotentials(fg_state=fg.fg_state, value=np.zeros(15))
 
-#     log_potentials = graph.LogPotentials(fg_state=fg.fg_state, value=np.zeros(10))
-#     assert jnp.all(log_potentials["test"] == jnp.zeros(10))
-#     with pytest.raises(
-#         ValueError,
-#         match=re.escape(f"Invalid name {frozenset([1])} for log potentials updates."),
-#     ):
-#         fg.bp_state.log_potentials[[1]]
+    log_potentials = graph.LogPotentials(fg_state=fg.fg_state, value=np.zeros(10))
+    assert jnp.all(log_potentials["test"] == jnp.zeros(10))
 
 
-# def test_ftov_msgs():
-#     variable_group = vgroup.VariableDict(15, (0,))
-#     fg = graph.FactorGraph(variable_group)
-#     fg.add_factor(
-#         variable_names=[0],
-#         factor_configs=np.arange(10)[:, None],
-#         name="test",
-#     )
-#     with pytest.raises(
-#         ValueError,
-#         match=re.escape("Invalid names for setting messages"),
-#     ):
-#         fg.bp_state.ftov_msgs[[0], 0] = np.ones(10)
+def test_ftov_msgs():
+    vg = vgroup.VariableDict(15, (0,))
+    fg = graph.FactorGraph(vg)
+    fg.add_factor(
+        variables=[vg[0]],
+        factor_configs=np.arange(10)[:, None],
+        name="test",
+    )
+    with pytest.raises(
+        ValueError,
+        match=re.escape("Invalid names for setting messages"),
+    ):
+        fg.bp_state.ftov_msgs[0] = np.ones(10)
 
-#     with pytest.raises(
-#         ValueError,
-#         match=re.escape(
-#             "Given belief shape (10,) does not match expected shape (15,) for variable 0"
-#         ),
-#     ):
-#         fg.bp_state.ftov_msgs[0] = np.ones(10)
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "Given belief shape (10,) does not match expected shape (15,) for variable (0, 15)."
+        ),
+    ):
+        fg.bp_state.ftov_msgs[vg[0]] = np.ones(10)
 
-#     with pytest.raises(
-#         ValueError, match=re.escape("Expected messages shape (15,). Got (10,)")
-#     ):
-#         graph.FToVMessages(fg_state=fg.fg_state, value=np.zeros(10))
+    with pytest.raises(
+        ValueError, match=re.escape("Expected messages shape (15,). Got (10,)")
+    ):
+        graph.FToVMessages(fg_state=fg.fg_state, value=np.zeros(10))
 
-#     ftov_msgs = graph.FToVMessages(fg_state=fg.fg_state, value=np.zeros(15))
-#     with pytest.raises(
-#         TypeError, match=re.escape("'FToVMessages' object is not subscriptable")
-#     ):
-#         ftov_msgs[(10,)]
+    ftov_msgs = graph.FToVMessages(fg_state=fg.fg_state, value=np.zeros(15))
+    with pytest.raises(
+        TypeError, match=re.escape("'FToVMessages' object is not subscriptable")
+    ):
+        ftov_msgs[(10,)]
 
 
 def test_evidence():

--- a/tests/fg/test_graph.py
+++ b/tests/fg/test_graph.py
@@ -106,9 +106,9 @@ def test_log_potentials():
 
     with pytest.raises(
         ValueError,
-        match=re.escape("Invalid FactorGroup for log potentials updates."),
+        match=re.escape("Invalid FactorGroup queried to access log potentials."),
     ):
-        fg.bp_state.log_potentials[vg[0]] = np.zeros(10)
+        fg.bp_state.log_potentials[vg[0]]
 
     with pytest.raises(
         ValueError, match=re.escape("Expected log potentials shape (10,). Got (15,)")

--- a/tests/fg/test_graph.py
+++ b/tests/fg/test_graph.py
@@ -130,7 +130,7 @@ def test_ftov_msgs():
 
     with pytest.raises(
         ValueError,
-        match=re.escape("Invalid names for setting messages"),
+        match=re.escape("Provided variable is not in the FactorGraph"),
     ):
         fg.bp_state.ftov_msgs[0] = np.ones(10)
 
@@ -175,7 +175,7 @@ def test_evidence():
     with pytest.raises(
         ValueError,
         match=re.escape(
-            "Got evidence for a variable or a variable group not in the FactorGraph!"
+            "Got evidence for a variable or a VariableGroup not in the FactorGraph!"
         ),
     ):
         graph.update_evidence(

--- a/tests/fg/test_graph.py
+++ b/tests/fg/test_graph.py
@@ -16,30 +16,12 @@ def test_factor_graph():
     vg = vgroup.VariableDict(variable_names=(0,), num_states=15)
     fg = graph.FactorGraph(vg)
 
-    with pytest.raises(
-        ValueError,
-        match="A Factor or a FactorGroup is required",
-    ):
-        fg.add_factors(factor_group=None, factor=None)
-
     factor = enumeration_factor.EnumerationFactor(
         variables=[vg[0]],
         factor_configs=np.arange(15)[:, None],
         log_potentials=np.zeros(15),
     )
-
-    factor_group = enumeration.EnumerationFactorGroup(
-        variables_for_factors=[[vg[0]]],
-        factor_configs=np.arange(15)[:, None],
-        log_potentials=np.zeros(15),
-    )
-    with pytest.raises(
-        ValueError,
-        match="Cannot simultaneously add a Factor and a FactorGroup",
-    ):
-        fg.add_factors(factor_group=factor_group, factor=factor)
-
-    fg.add_factors(factor=factor)
+    fg.add_factors(factor)
 
     factor_group = enumeration.EnumerationFactorGroup(
         variables_for_factors=[[vg[0]]],
@@ -49,7 +31,7 @@ def test_factor_graph():
     with pytest.raises(
         ValueError,
         match=re.escape(
-            f"A Factor of type {enumeration_factor.EnumerationFactor} involving variables {frozenset([((vg.__hash__(), 0), 15)])} already exists."
+            f"A Factor of type {enumeration_factor.EnumerationFactor} involving variables {frozenset([(vg.__hash__(), 15)])} already exists."
         ),
     ):
         fg.add_factors(factor_group)
@@ -63,10 +45,10 @@ def test_bp_state():
         factor_configs=np.arange(15)[:, None],
         log_potentials=np.zeros(15),
     )
-    fg0.add_factors(factor=factor)
+    fg0.add_factors(factor)
 
     fg1 = graph.FactorGraph(vg)
-    fg1.add_factors(factor=factor)
+    fg1.add_factors(factor)
 
     with pytest.raises(
         ValueError,
@@ -137,7 +119,7 @@ def test_ftov_msgs():
     with pytest.raises(
         ValueError,
         match=re.escape(
-            f"Given belief shape (10,) does not match expected shape (15,) for variable (({vg.__hash__()}, 0), 15)."
+            f"Given belief shape (10,) does not match expected shape (15,) for variable ({vg.__hash__()}, 15)."
         ),
     ):
         fg.bp_state.ftov_msgs[vg[0]] = np.ones(10)

--- a/tests/fg/test_graph.py
+++ b/tests/fg/test_graph.py
@@ -109,6 +109,12 @@ def test_log_potentials():
 
     with pytest.raises(
         ValueError,
+        match=re.escape("Invalid name new_test for log potentials updates."),
+    ):
+        fg.bp_state.log_potentials["new_test"] = jnp.zeros((1, 15))
+
+    with pytest.raises(
+        ValueError,
         match=re.escape("Invalid name (0, 15) for log potentials updates."),
     ):
         fg.bp_state.log_potentials[vg[0]] = np.zeros(10)

--- a/tests/fg/test_graph.py
+++ b/tests/fg/test_graph.py
@@ -13,11 +13,11 @@ from pgmax.groups import variables as vgroup
 
 
 def test_factor_graph():
-    variable_group = vgroup.VariableDict(15, (0,))
-    fg = graph.FactorGraph(variable_group)
+    vg = vgroup.VariableDict(15, (0,))
+    fg = graph.FactorGraph(vg)
     fg.add_factor_by_type(
         factor_type=enumeration_factor.EnumerationFactor,
-        variable_names=[0],
+        variables=[vg[0]],
         factor_configs=np.arange(15)[:, None],
         log_potentials=np.zeros(15),
         name="test",
@@ -27,7 +27,7 @@ def test_factor_graph():
         match="A factor group with the name test already exists. Please choose a different name",
     ):
         fg.add_factor(
-            variable_names=[0],
+            variables=[vg[0]],
             factor_configs=np.arange(15)[:, None],
             name="test",
         )
@@ -35,11 +35,11 @@ def test_factor_graph():
     with pytest.raises(
         ValueError,
         match=re.escape(
-            f"A Factor of type {enumeration_factor.EnumerationFactor} involving variables {frozenset([0])} already exists."
+            f"A Factor of type {enumeration_factor.EnumerationFactor} involving variables {frozenset([(0, 15)])} already exists."
         ),
     ):
         fg.add_factor(
-            variable_names=[0],
+            variables=[vg[0]],
             factor_configs=np.arange(10)[:, None],
         )
 
@@ -49,46 +49,43 @@ def test_factor_graph():
             f"Type {groups.FactorGroup} is not one of the supported factor types {FAC_TO_VAR_UPDATES.keys()}"
         ),
     ):
-        fg.add_factor_by_type(variable_names=[0], factor_type=groups.FactorGroup)
+        fg.add_factor_by_type(variables=[vg[0]], factor_type=groups.FactorGroup)
 
 
 def test_factor_adding():
     A = vgroup.NDVariableArray(num_states=2, shape=(10,))
     B = vgroup.NDVariableArray(num_states=2, shape=(10,))
-    fg = graph.FactorGraph(variables=dict(A=A, B=B))
+    fg = graph.FactorGraph(variables=[A, B])
 
     with pytest.raises(ValueError, match="Do not add a factor group with no factors."):
         fg.add_factor_group(
             factory=logical.ORFactorGroup,
-            variable_names_for_factors=[],
+            variables_for_factors=[],
         )
 
-    variables0 = [("A", 0), ("B", 0)]
-    variables1 = [("A", 1), ("B", 1)]
-    ORFactor = logical.ORFactorGroup(
-        fg._variable_group, variable_names_for_factors=[variables0]
-    )
+    variables0 = (A[0], B[0])
+    variables1 = (A[1], B[1])
+    ORFactor = logical.ORFactorGroup(variables_for_factors=[variables0])
     with pytest.raises(
         ValueError, match="SingleFactorGroup should only contain one factor. Got 2"
     ):
         groups.SingleFactorGroup(
-            variable_group=fg._variable_group,
-            variable_names_for_factors=[variables0, variables1],
+            variables_for_factors=[variables0, variables1],
             factor=ORFactor,
         )
 
 
 def test_bp_state():
-    variable_group = vgroup.VariableDict(15, (0,))
-    fg0 = graph.FactorGraph(variable_group)
+    vg = vgroup.VariableDict(15, (0,))
+    fg0 = graph.FactorGraph(vg)
     fg0.add_factor(
-        variable_names=[0],
+        variables=[vg[0]],
         factor_configs=np.arange(10)[:, None],
         name="test",
     )
-    fg1 = graph.FactorGraph(variable_group)
+    fg1 = graph.FactorGraph(vg)
     fg1.add_factor(
-        variable_names=[0],
+        variables=[vg[0]],
         factor_configs=np.arange(15)[:, None],
         name="test",
     )
@@ -103,79 +100,79 @@ def test_bp_state():
         )
 
 
-def test_log_potentials():
-    variable_group = vgroup.VariableDict(15, (0,))
-    fg = graph.FactorGraph(variable_group)
-    fg.add_factor(
-        variable_names=[0],
-        factor_configs=np.arange(10)[:, None],
-        name="test",
-    )
-    with pytest.raises(
-        ValueError,
-        match=re.escape("Expected log potentials shape (10,) for factor group test."),
-    ):
-        fg.bp_state.log_potentials["test"] = jnp.zeros((1, 15))
+# def test_log_potentials():
+#     vg = vgroup.VariableDict(15, (0,))
+#     fg = graph.FactorGraph(vg)
+#     fg.add_factor(
+#         variables=[vg[0]],
+#         factor_configs=np.arange(10)[:, None],
+#         name="test",
+#     )
+#     with pytest.raises(
+#         ValueError,
+#         match=re.escape("Expected log potentials shape (10,) for factor group test."),
+#     ):
+#         fg.bp_state.log_potentials["test"] = jnp.zeros((1, 15))
 
-    with pytest.raises(
-        ValueError,
-        match=re.escape(f"Invalid name {frozenset([0])} for log potentials updates."),
-    ):
-        fg.bp_state.log_potentials[[0]] = np.zeros(10)
+#     with pytest.raises(
+#         ValueError,
+#         match=re.escape(f"Invalid name {frozenset([0])} for log potentials updates."),
+#     ):
+#         fg.bp_state.log_potentials[vg[0]] = np.zeros(10)
 
-    with pytest.raises(
-        ValueError, match=re.escape("Expected log potentials shape (10,). Got (15,)")
-    ):
-        graph.LogPotentials(fg_state=fg.fg_state, value=np.zeros(15))
+#     with pytest.raises(
+#         ValueError, match=re.escape("Expected log potentials shape (10,). Got (15,)")
+#     ):
+#         graph.LogPotentials(fg_state=fg.fg_state, value=np.zeros(15))
 
-    log_potentials = graph.LogPotentials(fg_state=fg.fg_state, value=np.zeros(10))
-    assert jnp.all(log_potentials["test"] == jnp.zeros(10))
-    with pytest.raises(
-        ValueError,
-        match=re.escape(f"Invalid name {frozenset([1])} for log potentials updates."),
-    ):
-        fg.bp_state.log_potentials[[1]]
+#     log_potentials = graph.LogPotentials(fg_state=fg.fg_state, value=np.zeros(10))
+#     assert jnp.all(log_potentials["test"] == jnp.zeros(10))
+#     with pytest.raises(
+#         ValueError,
+#         match=re.escape(f"Invalid name {frozenset([1])} for log potentials updates."),
+#     ):
+#         fg.bp_state.log_potentials[[1]]
 
 
-def test_ftov_msgs():
-    variable_group = vgroup.VariableDict(15, (0,))
-    fg = graph.FactorGraph(variable_group)
-    fg.add_factor(
-        variable_names=[0],
-        factor_configs=np.arange(10)[:, None],
-        name="test",
-    )
-    with pytest.raises(
-        ValueError,
-        match=re.escape("Invalid names for setting messages"),
-    ):
-        fg.bp_state.ftov_msgs[[0], 0] = np.ones(10)
+# def test_ftov_msgs():
+#     variable_group = vgroup.VariableDict(15, (0,))
+#     fg = graph.FactorGraph(variable_group)
+#     fg.add_factor(
+#         variable_names=[0],
+#         factor_configs=np.arange(10)[:, None],
+#         name="test",
+#     )
+#     with pytest.raises(
+#         ValueError,
+#         match=re.escape("Invalid names for setting messages"),
+#     ):
+#         fg.bp_state.ftov_msgs[[0], 0] = np.ones(10)
 
-    with pytest.raises(
-        ValueError,
-        match=re.escape(
-            "Given belief shape (10,) does not match expected shape (15,) for variable 0"
-        ),
-    ):
-        fg.bp_state.ftov_msgs[0] = np.ones(10)
+#     with pytest.raises(
+#         ValueError,
+#         match=re.escape(
+#             "Given belief shape (10,) does not match expected shape (15,) for variable 0"
+#         ),
+#     ):
+#         fg.bp_state.ftov_msgs[0] = np.ones(10)
 
-    with pytest.raises(
-        ValueError, match=re.escape("Expected messages shape (15,). Got (10,)")
-    ):
-        graph.FToVMessages(fg_state=fg.fg_state, value=np.zeros(10))
+#     with pytest.raises(
+#         ValueError, match=re.escape("Expected messages shape (15,). Got (10,)")
+#     ):
+#         graph.FToVMessages(fg_state=fg.fg_state, value=np.zeros(10))
 
-    ftov_msgs = graph.FToVMessages(fg_state=fg.fg_state, value=np.zeros(15))
-    with pytest.raises(
-        TypeError, match=re.escape("'FToVMessages' object is not subscriptable")
-    ):
-        ftov_msgs[(10,)]
+#     ftov_msgs = graph.FToVMessages(fg_state=fg.fg_state, value=np.zeros(15))
+#     with pytest.raises(
+#         TypeError, match=re.escape("'FToVMessages' object is not subscriptable")
+#     ):
+#         ftov_msgs[(10,)]
 
 
 def test_evidence():
-    variable_group = vgroup.VariableDict(15, (0,))
-    fg = graph.FactorGraph(variable_group)
+    vg = vgroup.VariableDict(15, (0,))
+    fg = graph.FactorGraph(vg)
     fg.add_factor(
-        variable_names=[0],
+        variables=[vg[0]],
         factor_configs=np.arange(10)[:, None],
         name="test",
     )
@@ -189,10 +186,10 @@ def test_evidence():
 
 
 def test_bp():
-    variable_group = vgroup.VariableDict(15, (0,))
-    fg = graph.FactorGraph(variable_group)
+    vg = vgroup.VariableDict(15, (0,))
+    fg = graph.FactorGraph(vg)
     fg.add_factor(
-        variable_names=[0],
+        variables=[vg[0]],
         factor_configs=np.arange(10)[:, None],
         name="test",
     )
@@ -200,7 +197,7 @@ def test_bp():
     bp_arrays = bp.update()
     bp_arrays = bp.update(
         bp_arrays=bp_arrays,
-        ftov_msgs_updates={0: np.zeros(15)},
+        ftov_msgs_updates={vg[0]: np.zeros(15)},
     )
     bp_arrays = bp.run_bp(bp_arrays, num_iters=1)
     bp_arrays = replace(bp_arrays, log_potentials=jnp.zeros((10)))

--- a/tests/fg/test_groups.py
+++ b/tests/fg/test_groups.py
@@ -54,7 +54,7 @@ def test_variable_dict():
 
 
 def test_nd_variable_array():
-    max_size = int(groups.MAX_SIZE)
+    max_size = int(vgroup.MAX_SIZE)
     with pytest.raises(
         ValueError,
         match=re.escape(

--- a/tests/fg/test_groups.py
+++ b/tests/fg/test_groups.py
@@ -10,7 +10,7 @@ from pgmax.groups import variables as vgroup
 
 
 def test_variable_dict():
-    variable_dict = vgroup.VariableDict(15, tuple([0, 1, 2]))
+    variable_dict = vgroup.VariableDict(variable_names=tuple([0, 1, 2]), num_states=15)
     with pytest.raises(
         ValueError, match="data is referring to a non-existent variable 3"
     ):
@@ -19,10 +19,10 @@ def test_variable_dict():
     with pytest.raises(
         ValueError,
         match=re.escape(
-            "Variable 2 expects a data array of shape (15,) or (1,). Got (10,)"
+            "Variable (2, 15) expects a data array of shape (15,) or (1,). Got (10,)"
         ),
     ):
-        variable_dict.flatten({2: np.zeros(10)})
+        variable_dict.flatten({(2, 15): np.zeros(10)})
 
     with pytest.raises(
         ValueError, match="Can only unflatten 1D array. Got a 2D array."

--- a/tests/fg/test_groups.py
+++ b/tests/fg/test_groups.py
@@ -54,6 +54,15 @@ def test_variable_dict():
 
 
 def test_nd_variable_array():
+    max_size = int(groups.MAX_SIZE)
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            f"Currently only support NDVariableArray of size smaller than {max_size}. Got {max_size + 1}"
+        ),
+    ):
+        vgroup.NDVariableArray(shape=(max_size + 1,), num_states=2)
+
     num_states = np.full((2, 3), fill_value=2)
     with pytest.raises(
         ValueError, match=re.escape("Expected num_states shape (2, 2). Got (2, 3).")
@@ -62,14 +71,19 @@ def test_nd_variable_array():
 
     num_states = np.full((2, 3), fill_value=2, dtype=np.float32)
     with pytest.raises(
-        ValueError, match=re.escape("num_states entries should be of type np.int")
+        ValueError,
+        match=re.escape(
+            "num_states should be an integer or a NumPy array of dtype int"
+        ),
     ):
         vgroup.NDVariableArray(shape=(2, 2), num_states=num_states)
 
-    variable_group = vgroup.NDVariableArray(shape=(5, 5), num_states=2)
-    assert len(variable_group[:3, :3]) == 9
+    variable_group0 = vgroup.NDVariableArray(shape=(5, 5), num_states=2)
+    assert len(variable_group0[:3, :3]) == 9
 
     variable_group = vgroup.NDVariableArray(shape=(2, 2), num_states=3)
+    variable_group0 < variable_group
+
     with pytest.raises(
         ValueError,
         match=re.escape("data should be of shape (2, 2) or (2, 2, 3). Got (3, 3)."),

--- a/tests/fg/test_groups.py
+++ b/tests/fg/test_groups.py
@@ -24,7 +24,7 @@ def test_variable_dict():
             "num_states should be an integer or a NumPy array of dtype int"
         ),
     ):
-        vgroup.NDVariableArray(shape=(2, 2), num_states=num_states)
+        vgroup.VariableDict(variable_names=tuple([0, 1, 2]), num_states=num_states)
 
     variable_dict = vgroup.VariableDict(variable_names=tuple([0, 1, 2]), num_states=15)
     with pytest.raises(

--- a/tests/fg/test_groups.py
+++ b/tests/fg/test_groups.py
@@ -94,6 +94,9 @@ def test_nd_variable_array():
 
 def test_enumeration_factor_group():
     vg = vgroup.NDVariableArray(shape=(2, 2), num_states=3)
+    vg_bis = vgroup.NDVariableArray(shape=(2, 2), num_states=3)
+    vg < vg_bis
+
     with pytest.raises(
         ValueError,
         match=re.escape("Expected log potentials shape: (1,) or (2, 1). Got (3, 2)"),

--- a/tests/fg/test_groups.py
+++ b/tests/fg/test_groups.py
@@ -5,81 +5,8 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
-from pgmax.fg import groups, nodes
 from pgmax.groups import enumeration
 from pgmax.groups import variables as vgroup
-
-
-def test_composite_variable_group():
-    variable_dict1 = vgroup.VariableDict(15, tuple([0, 1, 2]))
-    variable_dict2 = vgroup.VariableDict(15, tuple([0, 1, 2]))
-    composite_variable_sequence = groups.CompositeVariableGroup(
-        [variable_dict1, variable_dict2]
-    )
-    composite_variable_dict = groups.CompositeVariableGroup(
-        {(0, 1): variable_dict1, (2, 3): variable_dict2}
-    )
-    with pytest.raises(ValueError, match="The name needs to have at least 2 elements"):
-        composite_variable_sequence[(0,)]
-
-    assert composite_variable_sequence[0, 1] == variable_dict1[1]
-    assert (
-        composite_variable_sequence[[(0, 1), (1, 2)]]
-        == composite_variable_dict[[((0, 1), 1), ((2, 3), 2)]]
-    )
-    assert composite_variable_dict[(0, 1), 0] == variable_dict1[0]
-    assert composite_variable_dict[[((0, 1), 1), ((2, 3), 2)]] == [
-        variable_dict1[1],
-        variable_dict2[2],
-    ]
-    assert jnp.all(
-        composite_variable_sequence.flatten(
-            [{name: np.zeros(15) for name in range(3)} for _ in range(2)]
-        )
-        == composite_variable_dict.flatten(
-            {
-                (0, 1): {name: np.zeros(15) for name in range(3)},
-                (2, 3): {name: np.zeros(15) for name in range(3)},
-            }
-        )
-    )
-    assert jnp.all(
-        jnp.array(
-            jax.tree_util.tree_leaves(
-                jax.tree_util.tree_multimap(
-                    lambda x, y: jnp.all(x == y),
-                    composite_variable_sequence.unflatten(jnp.zeros(15 * 3 * 2)),
-                    [{name: jnp.zeros(15) for name in range(3)} for _ in range(2)],
-                )
-            )
-        )
-    )
-    assert jnp.all(
-        jnp.array(
-            jax.tree_util.tree_leaves(
-                jax.tree_util.tree_multimap(
-                    lambda x, y: jnp.all(x == y),
-                    composite_variable_dict.unflatten(jnp.zeros(3 * 2)),
-                    {
-                        (0, 1): {name: np.zeros(1) for name in range(3)},
-                        (2, 3): {name: np.zeros(1) for name in range(3)},
-                    },
-                )
-            )
-        )
-    )
-    with pytest.raises(
-        ValueError, match="Can only unflatten 1D array. Got a 2D array."
-    ):
-        composite_variable_dict.unflatten(jnp.zeros((10, 20)))
-
-    with pytest.raises(
-        ValueError,
-        match=re.escape(
-            "flat_data should be either of shape (num_variables(=6),), or (num_variable_states(=90),)"
-        ),
-    ):
-        composite_variable_dict.unflatten(jnp.zeros((100)))
 
 
 def test_variable_dict():
@@ -123,9 +50,7 @@ def test_variable_dict():
 
 
 def test_nd_variable_array():
-    variable_group = vgroup.NDVariableArray(2, (1,))
-    assert isinstance(variable_group[0], nodes.Variable)
-    variable_group = vgroup.NDVariableArray(3, (2, 2))
+    variable_group = vgroup.NDVariableArray(shape=(2, 2), num_states=3)
     with pytest.raises(
         ValueError,
         match=re.escape("data should be of shape (2, 2) or (2, 2, 3). Got (3, 3)."),
@@ -153,16 +78,15 @@ def test_nd_variable_array():
 
 
 def test_enumeration_factor_group():
-    variable_group = vgroup.NDVariableArray(3, (2, 2))
+    vg = vgroup.NDVariableArray(shape=(2, 2), num_states=3)
     with pytest.raises(
         ValueError,
         match=re.escape("Expected log potentials shape: (1,) or (2, 1). Got (3, 2)"),
     ):
         enumeration_factor_group = enumeration.EnumerationFactorGroup(
-            variable_group=variable_group,
-            variable_names_for_factors=[
-                [(0, 0), (0, 1), (1, 1)],
-                [(0, 1), (1, 0), (1, 1)],
+            variables_for_factors=[
+                [vg[0, 0], vg[0, 1], vg[1, 1]],
+                [vg[0, 1], vg[1, 0], vg[1, 1]],
             ],
             factor_configs=np.zeros((1, 3), dtype=int),
             log_potentials=np.zeros((3, 2)),
@@ -170,21 +94,22 @@ def test_enumeration_factor_group():
 
     with pytest.raises(ValueError, match=re.escape("Potentials should be floats")):
         enumeration_factor_group = enumeration.EnumerationFactorGroup(
-            variable_group=variable_group,
-            variable_names_for_factors=[
-                [(0, 0), (0, 1), (1, 1)],
-                [(0, 1), (1, 0), (1, 1)],
+            variables_for_factors=[
+                [vg[0, 0], vg[0, 1], vg[1, 1]],
+                [vg[0, 1], vg[1, 0], vg[1, 1]],
             ],
             factor_configs=np.zeros((1, 3), dtype=int),
             log_potentials=np.zeros((2, 1), dtype=int),
         )
 
     enumeration_factor_group = enumeration.EnumerationFactorGroup(
-        variable_group=variable_group,
-        variable_names_for_factors=[[(0, 0), (0, 1), (1, 1)], [(0, 1), (1, 0), (1, 1)]],
+        variables_for_factors=[
+            [vg[0, 0], vg[0, 1], vg[1, 1]],
+            [vg[0, 1], vg[1, 0], vg[1, 1]],
+        ],
         factor_configs=np.zeros((1, 3), dtype=int),
     )
-    name = [(0, 0), (1, 1)]
+    name = [vg[0, 0], vg[1, 1]]
     with pytest.raises(
         ValueError,
         match=re.escape(
@@ -194,7 +119,7 @@ def test_enumeration_factor_group():
         enumeration_factor_group[name]
 
     assert (
-        enumeration_factor_group[[(0, 1), (1, 0), (1, 1)]]
+        enumeration_factor_group[[vg[0, 1], vg[1, 0], vg[1, 1]]]
         == enumeration_factor_group.factors[1]
     )
     with pytest.raises(
@@ -227,20 +152,20 @@ def test_enumeration_factor_group():
 
 
 def test_pairwise_factor_group():
-    variable_group = vgroup.NDVariableArray(3, (2, 2))
+    vg = vgroup.NDVariableArray(shape=(2, 2), num_states=3)
 
     with pytest.raises(
         ValueError, match=re.escape("log_potential_matrix should be either a 2D array")
     ):
         enumeration.PairwiseFactorGroup(
-            variable_group, [[(0, 0), (1, 1)]], np.zeros((1,), dtype=float)
+            [[vg[0, 0], vg[1, 1]]], np.zeros((1,), dtype=float)
         )
 
     with pytest.raises(
         ValueError, match=re.escape("Potential matrix should be floats")
     ):
         enumeration.PairwiseFactorGroup(
-            variable_group, [[(0, 0), (1, 1)]], np.zeros((3, 3), dtype=int)
+            [[vg[0, 0], vg[1, 1]]], np.zeros((3, 3), dtype=int)
         )
 
     with pytest.raises(
@@ -250,7 +175,7 @@ def test_pairwise_factor_group():
         ),
     ):
         enumeration.PairwiseFactorGroup(
-            variable_group, [[(0, 0), (1, 1)]], np.zeros((2, 3, 3), dtype=float)
+            [[vg[0, 0], vg[1, 1]]], np.zeros((2, 3, 3), dtype=float)
         )
 
     with pytest.raises(
@@ -260,20 +185,18 @@ def test_pairwise_factor_group():
         ),
     ):
         enumeration.PairwiseFactorGroup(
-            variable_group, [[(0, 0), (1, 1), (0, 1)]], np.zeros((3, 3), dtype=float)
+            [[vg[0, 0], vg[1, 1], vg[0, 1]]], np.zeros((3, 3), dtype=float)
         )
 
+    name = [vg[0, 0], vg[1, 1]]
     with pytest.raises(
         ValueError,
-        match=re.escape("The specified pairwise factor [(0, 0), (1, 1)]"),
+        match=re.escape(f"The specified pairwise factor {name}"),
     ):
-        enumeration.PairwiseFactorGroup(
-            variable_group, [[(0, 0), (1, 1)]], np.zeros((4, 4), dtype=float)
-        )
+        enumeration.PairwiseFactorGroup([name], np.zeros((4, 4), dtype=float))
 
     pairwise_factor_group = enumeration.PairwiseFactorGroup(
-        variable_group,
-        [[(0, 0), (1, 1)], [(1, 0), (0, 1)]],
+        [[vg[0, 0], vg[1, 1]], [vg[1, 0], vg[0, 1]]],
     )
     with pytest.raises(
         ValueError,

--- a/tests/fg/test_groups.py
+++ b/tests/fg/test_groups.py
@@ -111,7 +111,13 @@ def test_nd_variable_array():
         variable_group.unflatten(np.zeros((12,)))
 
     assert jnp.all(variable_group.unflatten(np.zeros(4)) == jnp.zeros((2, 2)))
-    assert jnp.all(variable_group.unflatten(np.zeros(10)) == jnp.zeros((2, 2, 4)))
+    unflattened = jnp.full((2, 2, 4), fill_value=jnp.nan)
+    unflattened = unflattened.at[0, 0, 0].set(0)
+    unflattened = unflattened.at[0, 1, :1].set(0)
+    unflattened = unflattened.at[1, 0, :2].set(0)
+    unflattened = unflattened.at[1, 1].set(0)
+    mask = ~jnp.isnan(unflattened)
+    assert jnp.all(variable_group.unflatten(np.zeros(10))[mask] == unflattened[mask])
 
 
 def test_single_factor():

--- a/tests/fg/test_groups.py
+++ b/tests/fg/test_groups.py
@@ -50,6 +50,21 @@ def test_variable_dict():
 
 
 def test_nd_variable_array():
+    num_states = np.full((2, 3), fill_value=2)
+    with pytest.raises(
+        ValueError, match=re.escape("Expected num_states shape (2, 2). Got (2, 3).")
+    ):
+        vgroup.NDVariableArray(shape=(2, 2), num_states=num_states)
+
+    num_states = np.full((2, 3), fill_value=2, dtype=np.float32)
+    with pytest.raises(
+        ValueError, match=re.escape("num_states entries should be of type np.int")
+    ):
+        vgroup.NDVariableArray(shape=(2, 2), num_states=num_states)
+
+    variable_group = vgroup.NDVariableArray(shape=(5, 5), num_states=2)
+    assert len(variable_group[:3, :3]) == 9
+
     variable_group = vgroup.NDVariableArray(shape=(2, 2), num_states=3)
     with pytest.raises(
         ValueError,

--- a/tests/fg/test_groups.py
+++ b/tests/fg/test_groups.py
@@ -35,7 +35,7 @@ def test_variable_dict():
                 jax.tree_util.tree_multimap(
                     lambda x, y: jnp.all(x == y),
                     variable_dict.unflatten(jnp.zeros(3)),
-                    {name: np.zeros(1) for name in range(3)},
+                    {(name, 15): np.zeros(1) for name in range(3)},
                 )
             )
         )

--- a/tests/fg/test_nodes.py
+++ b/tests/fg/test_nodes.py
@@ -5,36 +5,37 @@ import pytest
 
 from pgmax.factors import enumeration, logical
 from pgmax.fg import nodes
+from pgmax.groups import variables as vgroup
 
 
 def test_enumeration_factor():
-    variable = nodes.Variable(3)
+    variables = vgroup.NDVariableArray(num_states=3, shape=(1,))
 
     with pytest.raises(
         NotImplementedError, match="Please implement compile_wiring in for your factor"
     ):
         nodes.Factor(
-            variables=(variable,),
+            variables=[variables[0]],
             log_potentials=np.array([0.0]),
         )
 
     with pytest.raises(ValueError, match="Configurations should be integers. Got"):
         enumeration.EnumerationFactor(
-            variables=(variable,),
+            variables=[variables[0]],
             factor_configs=np.array([[1.0]]),
             log_potentials=np.array([0.0]),
         )
 
     with pytest.raises(ValueError, match="Potential should be floats. Got"):
         enumeration.EnumerationFactor(
-            variables=(variable,),
+            variables=[variables[0]],
             factor_configs=np.array([[1]]),
             log_potentials=np.array([0]),
         )
 
     with pytest.raises(ValueError, match="factor_configs should be a 2D array"):
         enumeration.EnumerationFactor(
-            variables=(variable,),
+            variables=[variables[0]],
             factor_configs=np.array([1]),
             log_potentials=np.array([0.0]),
         )
@@ -46,7 +47,7 @@ def test_enumeration_factor():
         ),
     ):
         enumeration.EnumerationFactor(
-            variables=(variable,),
+            variables=[variables[0]],
             factor_configs=np.array([[1, 2]]),
             log_potentials=np.array([0.0]),
         )
@@ -55,27 +56,27 @@ def test_enumeration_factor():
         ValueError, match=re.escape("Expected log potentials of shape (1,)")
     ):
         enumeration.EnumerationFactor(
-            variables=(variable,),
+            variables=[variables[0]],
             factor_configs=np.array([[1]]),
             log_potentials=np.array([0.0, 1.0]),
         )
 
     with pytest.raises(ValueError, match="Invalid configurations for given variables"):
         enumeration.EnumerationFactor(
-            variables=(variable,),
+            variables=[variables[0]],
             factor_configs=np.array([[10]]),
             log_potentials=np.array([0.0]),
         )
 
 
 def test_logical_factor():
-    child = nodes.Variable(2)
-    wrong_parent = nodes.Variable(3)
-    parent = nodes.Variable(2)
+    child = vgroup.NDVariableArray(num_states=2, shape=(1,))[0]
+    wrong_parent = vgroup.NDVariableArray(num_states=3, shape=(1,))[0]
+    parent = vgroup.NDVariableArray(num_states=2, shape=(1,))[0]
 
     with pytest.raises(
         ValueError,
-        match="At least one parent variable and one child variable is required",
+        match="A LogicalFactor requires at least one parent variable and one child variable",
     ):
         logical.LogicalFactor(
             variables=(child,),
@@ -100,7 +101,7 @@ def test_logical_factor():
 
     with pytest.raises(ValueError, match="The highest LogicalFactor index must be 0"):
         logical.LogicalWiring(
-            edges_num_states=logical_factor.edges_num_states,
+            edges_num_states=[2, 2],
             var_states_for_edges=None,
             parents_edge_states=parents_edge_states + np.array([[1, 0]]),
             children_edge_states=child_edge_state,
@@ -112,7 +113,7 @@ def test_logical_factor():
         match="The LogicalWiring must have 1 different LogicalFactor indices",
     ):
         logical.LogicalWiring(
-            edges_num_states=logical_factor.edges_num_states,
+            edges_num_states=[2, 2],
             var_states_for_edges=None,
             parents_edge_states=parents_edge_states + np.array([[0], [1]]),
             children_edge_states=child_edge_state,
@@ -126,7 +127,7 @@ def test_logical_factor():
         ),
     ):
         logical.LogicalWiring(
-            edges_num_states=logical_factor.edges_num_states,
+            edges_num_states=[2, 2],
             var_states_for_edges=None,
             parents_edge_states=parents_edge_states,
             children_edge_states=child_edge_state,

--- a/tests/fg/test_wiring.py
+++ b/tests/fg/test_wiring.py
@@ -20,10 +20,11 @@ def test_wiring_with_PairwiseFactorGroup():
 
     # First test that compile_wiring enforces the correct factor_edges_num_states shape
     fg = graph.FactorGraph(variables=[A, B])
-    fg.add_factor_group(
-        factory=enumeration.PairwiseFactorGroup,
-        variables_for_factors=[[A[idx], B[idx]] for idx in range(10)],
+    factor_group = enumeration.PairwiseFactorGroup(
+        variables_for_factors=[[A[idx], B[idx]] for idx in range(10)]
     )
+    fg.add_factor_group(factor_group)
+
     factor_group = fg.factor_groups[enumeration_factor.EnumerationFactor][0]
     object.__setattr__(
         factor_group, "factor_configs", factor_group.factor_configs[:, :1]
@@ -36,32 +37,30 @@ def test_wiring_with_PairwiseFactorGroup():
 
     # FactorGraph with a single PairwiseFactorGroup
     fg1 = graph.FactorGraph(variables=[A, B])
-    fg1.add_factor_group(
-        factory=enumeration.PairwiseFactorGroup,
-        variables_for_factors=[[A[idx], B[idx]] for idx in range(10)],
+    factor_group = enumeration.PairwiseFactorGroup(
+        variables_for_factors=[[A[idx], B[idx]] for idx in range(10)]
     )
+    fg1.add_factor_group(factor_group)
     assert len(fg1.factor_groups[enumeration_factor.EnumerationFactor]) == 1
 
     # FactorGraph with multiple PairwiseFactorGroup
     fg2 = graph.FactorGraph(variables=[A, B])
     for idx in range(10):
-        fg2.add_factor_group(
-            factory=enumeration.PairwiseFactorGroup,
-            variables_for_factors=[[A[idx], B[idx]]],
+        factor_group = enumeration.PairwiseFactorGroup(
+            variables_for_factors=[[A[idx], B[idx]]]
         )
+        fg2.add_factor_group(factor_group)
     assert len(fg2.factor_groups[enumeration_factor.EnumerationFactor]) == 10
 
     # FactorGraph with multiple SingleFactorGroup
     fg3 = graph.FactorGraph(variables=[A, B])
     for idx in range(10):
-        fg3.add_factor_by_type(
+        factor = enumeration_factor.EnumerationFactor(
             variables=[A[idx], B[idx]],
-            factor_type=enumeration_factor.EnumerationFactor,
-            **{
-                "factor_configs": np.array([[0, 0], [0, 1], [1, 0], [1, 1]]),
-                "log_potentials": np.zeros((4,)),
-            }
+            factor_configs=np.array([[0, 0], [0, 1], [1, 0], [1, 1]]),
+            log_potentials=np.zeros((4,)),
         )
+        fg3.add_factor(factor)
     assert len(fg3.factor_groups[enumeration_factor.EnumerationFactor]) == 10
 
     assert len(fg1.factors) == len(fg2.factors) == len(fg3.factors)
@@ -97,28 +96,28 @@ def test_wiring_with_ORFactorGroup():
 
     # FactorGraph with a single ORFactorGroup
     fg1 = graph.FactorGraph(variables=[A, B, C])
-    fg1.add_factor_group(
-        factory=logical.ORFactorGroup,
+    factor_group = logical.ORFactorGroup(
         variables_for_factors=[[A[idx], B[idx], C[idx]] for idx in range(10)],
     )
+    fg1.add_factor_group(factor_group)
     assert len(fg1.factor_groups[logical_factor.ORFactor]) == 1
 
     # FactorGraph with multiple ORFactorGroup
     fg2 = graph.FactorGraph(variables=[A, B, C])
     for idx in range(10):
-        fg2.add_factor_group(
-            factory=logical.ORFactorGroup,
+        factor_group = logical.ORFactorGroup(
             variables_for_factors=[[A[idx], B[idx], C[idx]]],
         )
+        fg2.add_factor_group(factor_group)
     assert len(fg2.factor_groups[logical_factor.ORFactor]) == 10
 
     # FactorGraph with multiple SingleFactorGroup
     fg3 = graph.FactorGraph(variables=[A, B, C])
     for idx in range(10):
-        fg3.add_factor_by_type(
+        factor = logical_factor.ORFactor(
             variables=[A[idx], B[idx], C[idx]],
-            factor_type=logical_factor.ORFactor,
         )
+        fg3.add_factor(factor)
     assert len(fg3.factor_groups[logical_factor.ORFactor]) == 10
 
     assert len(fg1.factors) == len(fg2.factors) == len(fg3.factors)
@@ -152,28 +151,28 @@ def test_wiring_with_ANDFactorGroup():
 
     # FactorGraph with a single ANDFactorGroup
     fg1 = graph.FactorGraph(variables=[A, B, C])
-    fg1.add_factor_group(
-        factory=logical.ANDFactorGroup,
+    factor_group = logical.ANDFactorGroup(
         variables_for_factors=[[A[idx], B[idx], C[idx]] for idx in range(10)],
     )
+    fg1.add_factor_group(factor_group)
     assert len(fg1.factor_groups[logical_factor.ANDFactor]) == 1
 
     # FactorGraph with multiple ANDFactorGroup
     fg2 = graph.FactorGraph(variables=[A, B, C])
     for idx in range(10):
-        fg2.add_factor_group(
-            factory=logical.ANDFactorGroup,
+        factor_group = logical.ANDFactorGroup(
             variables_for_factors=[[A[idx], B[idx], C[idx]]],
         )
+        fg2.add_factor_group(factor_group)
     assert len(fg2.factor_groups[logical_factor.ANDFactor]) == 10
 
     # FactorGraph with multiple SingleFactorGroup
     fg3 = graph.FactorGraph(variables=[A, B, C])
     for idx in range(10):
-        fg3.add_factor_by_type(
+        factor = logical_factor.ANDFactor(
             variables=[A[idx], B[idx], C[idx]],
-            factor_type=logical_factor.ANDFactor,
         )
+        fg3.add_factor(factor)
     assert len(fg3.factor_groups[logical_factor.ANDFactor]) == 10
 
     assert len(fg1.factors) == len(fg2.factors) == len(fg3.factors)

--- a/tests/fg/test_wiring.py
+++ b/tests/fg/test_wiring.py
@@ -25,7 +25,7 @@ def test_wiring_with_PairwiseFactorGroup():
     )
     fg.add_factors(factor_group)
 
-    factor_group = fg.factor_groups[0]
+    factor_group = fg.factor_groups[enumeration_factor.EnumerationFactor][0]
     object.__setattr__(
         factor_group, "factor_configs", factor_group.factor_configs[:, :1]
     )
@@ -41,7 +41,7 @@ def test_wiring_with_PairwiseFactorGroup():
         variables_for_factors=[[A[idx], B[idx]] for idx in range(10)]
     )
     fg1.add_factors(factor_group)
-    assert len(fg1.factor_groups) == 1
+    assert len(fg1.factor_groups[enumeration_factor.EnumerationFactor]) == 1
 
     # FactorGraph with multiple PairwiseFactorGroup
     fg2 = graph.FactorGraph(variable_groups=[A, B])
@@ -50,18 +50,20 @@ def test_wiring_with_PairwiseFactorGroup():
             variables_for_factors=[[A[idx], B[idx]]]
         )
         fg2.add_factors(factor_group)
-    assert len(fg2.factor_groups) == 10
+    assert len(fg2.factor_groups[enumeration_factor.EnumerationFactor]) == 10
 
     # FactorGraph with multiple SingleFactorGroup
     fg3 = graph.FactorGraph(variable_groups=[A, B])
+    factors = []
     for idx in range(10):
         factor = enumeration_factor.EnumerationFactor(
             variables=[A[idx], B[idx]],
             factor_configs=np.array([[0, 0], [0, 1], [1, 0], [1, 1]]),
             log_potentials=np.zeros((4,)),
         )
-        fg3.add_factors(factor=factor)
-    assert len(fg3.factor_groups) == 10
+        factors.append(factor)
+    fg3.add_factors(factors)
+    assert len(fg3.factor_groups[enumeration_factor.EnumerationFactor]) == 10
 
     assert len(fg1.factors) == len(fg2.factors) == len(fg3.factors)
 
@@ -100,7 +102,7 @@ def test_wiring_with_ORFactorGroup():
         variables_for_factors=[[A[idx], B[idx], C[idx]] for idx in range(10)],
     )
     fg1.add_factors(factor_group)
-    assert len(fg1.factor_groups) == 1
+    assert len(fg1.factor_groups[logical_factor.ORFactor]) == 1
 
     # FactorGraph with multiple ORFactorGroup
     fg2 = graph.FactorGraph(variable_groups=[A, B, C])
@@ -109,7 +111,7 @@ def test_wiring_with_ORFactorGroup():
             variables_for_factors=[[A[idx], B[idx], C[idx]]],
         )
         fg2.add_factors(factor_group)
-    assert len(fg2.factor_groups) == 10
+    assert len(fg2.factor_groups[logical_factor.ORFactor]) == 10
 
     # FactorGraph with multiple SingleFactorGroup
     fg3 = graph.FactorGraph(variable_groups=[A, B, C])
@@ -117,8 +119,8 @@ def test_wiring_with_ORFactorGroup():
         factor = logical_factor.ORFactor(
             variables=[A[idx], B[idx], C[idx]],
         )
-        fg3.add_factors(factor=factor)
-    assert len(fg3.factor_groups) == 10
+        fg3.add_factors(factor)
+    assert len(fg3.factor_groups[logical_factor.ORFactor]) == 10
 
     assert len(fg1.factors) == len(fg2.factors) == len(fg3.factors)
 
@@ -155,7 +157,7 @@ def test_wiring_with_ANDFactorGroup():
         variables_for_factors=[[A[idx], B[idx], C[idx]] for idx in range(10)],
     )
     fg1.add_factors(factor_group)
-    assert len(fg1.factor_groups) == 1
+    assert len(fg1.factor_groups[logical_factor.ANDFactor]) == 1
 
     # FactorGraph with multiple ANDFactorGroup
     fg2 = graph.FactorGraph(variable_groups=[A, B, C])
@@ -164,7 +166,7 @@ def test_wiring_with_ANDFactorGroup():
             variables_for_factors=[[A[idx], B[idx], C[idx]]],
         )
         fg2.add_factors(factor_group)
-    assert len(fg2.factor_groups) == 10
+    assert len(fg2.factor_groups[logical_factor.ANDFactor]) == 10
 
     # FactorGraph with multiple SingleFactorGroup
     fg3 = graph.FactorGraph(variable_groups=[A, B, C])
@@ -172,8 +174,8 @@ def test_wiring_with_ANDFactorGroup():
         factor = logical_factor.ANDFactor(
             variables=[A[idx], B[idx], C[idx]],
         )
-        fg3.add_factors(factor=factor)
-    assert len(fg3.factor_groups) == 10
+        fg3.add_factors(factor)
+    assert len(fg3.factor_groups[logical_factor.ANDFactor]) == 10
 
     assert len(fg1.factors) == len(fg2.factors) == len(fg3.factors)
 

--- a/tests/fg/test_wiring.py
+++ b/tests/fg/test_wiring.py
@@ -22,17 +22,15 @@ def test_wiring_with_PairwiseFactorGroup():
     fg = graph.FactorGraph(variables=[A, B])
     fg.add_factor_group(
         factory=enumeration.PairwiseFactorGroup,
-        variable_names_for_factors=[[A[idx], B[idx]] for idx in range(10)],
+        variables_for_factors=[[A[idx], B[idx]] for idx in range(10)],
     )
     factor_group = fg.factor_groups[enumeration_factor.EnumerationFactor][0]
     object.__setattr__(
-        factor_group,
-        "factor_edges_num_states",
-        factor_group.factor_edges_num_states[:-1],
+        factor_group, "factor_configs", factor_group.factor_configs[:, :1]
     )
     with pytest.raises(
         ValueError,
-        match=re.escape("Expected factor_edges_num_states shape is (20,). Got (19,)."),
+        match=re.escape("Expected factor_edges_num_states shape is (10,). Got (20,)."),
     ):
         factor_group.compile_wiring(fg._vars_to_starts)
 
@@ -40,7 +38,7 @@ def test_wiring_with_PairwiseFactorGroup():
     fg1 = graph.FactorGraph(variables=[A, B])
     fg1.add_factor_group(
         factory=enumeration.PairwiseFactorGroup,
-        variable_names_for_factors=[[A[idx], B[idx]] for idx in range(10)],
+        variables_for_factors=[[A[idx], B[idx]] for idx in range(10)],
     )
     assert len(fg1.factor_groups[enumeration_factor.EnumerationFactor]) == 1
 
@@ -49,7 +47,7 @@ def test_wiring_with_PairwiseFactorGroup():
     for idx in range(10):
         fg2.add_factor_group(
             factory=enumeration.PairwiseFactorGroup,
-            variable_names_for_factors=[[A[idx], B[idx]]],
+            variables_for_factors=[[A[idx], B[idx]]],
         )
     assert len(fg2.factor_groups[enumeration_factor.EnumerationFactor]) == 10
 
@@ -57,7 +55,7 @@ def test_wiring_with_PairwiseFactorGroup():
     fg3 = graph.FactorGraph(variables=[A, B])
     for idx in range(10):
         fg3.add_factor_by_type(
-            variable_names=[A[idx], B[idx]],
+            variables=[A[idx], B[idx]],
             factor_type=enumeration_factor.EnumerationFactor,
             **{
                 "factor_configs": np.array([[0, 0], [0, 1], [1, 0], [1, 1]]),
@@ -101,7 +99,7 @@ def test_wiring_with_ORFactorGroup():
     fg1 = graph.FactorGraph(variables=[A, B, C])
     fg1.add_factor_group(
         factory=logical.ORFactorGroup,
-        variable_names_for_factors=[[A[idx], B[idx], C[idx]] for idx in range(10)],
+        variables_for_factors=[[A[idx], B[idx], C[idx]] for idx in range(10)],
     )
     assert len(fg1.factor_groups[logical_factor.ORFactor]) == 1
 
@@ -110,7 +108,7 @@ def test_wiring_with_ORFactorGroup():
     for idx in range(10):
         fg2.add_factor_group(
             factory=logical.ORFactorGroup,
-            variable_names_for_factors=[[A[idx], B[idx], C[idx]]],
+            variables_for_factors=[[A[idx], B[idx], C[idx]]],
         )
     assert len(fg2.factor_groups[logical_factor.ORFactor]) == 10
 
@@ -118,7 +116,7 @@ def test_wiring_with_ORFactorGroup():
     fg3 = graph.FactorGraph(variables=[A, B, C])
     for idx in range(10):
         fg3.add_factor_by_type(
-            variable_names=[A[idx], B[idx], C[idx]],
+            variables=[A[idx], B[idx], C[idx]],
             factor_type=logical_factor.ORFactor,
         )
     assert len(fg3.factor_groups[logical_factor.ORFactor]) == 10
@@ -156,7 +154,7 @@ def test_wiring_with_ANDFactorGroup():
     fg1 = graph.FactorGraph(variables=[A, B, C])
     fg1.add_factor_group(
         factory=logical.ANDFactorGroup,
-        variable_names_for_factors=[[A[idx], B[idx], C[idx]] for idx in range(10)],
+        variables_for_factors=[[A[idx], B[idx], C[idx]] for idx in range(10)],
     )
     assert len(fg1.factor_groups[logical_factor.ANDFactor]) == 1
 
@@ -165,7 +163,7 @@ def test_wiring_with_ANDFactorGroup():
     for idx in range(10):
         fg2.add_factor_group(
             factory=logical.ANDFactorGroup,
-            variable_names_for_factors=[[A[idx], B[idx], C[idx]]],
+            variables_for_factors=[[A[idx], B[idx], C[idx]]],
         )
     assert len(fg2.factor_groups[logical_factor.ANDFactor]) == 10
 
@@ -173,7 +171,7 @@ def test_wiring_with_ANDFactorGroup():
     fg3 = graph.FactorGraph(variables=[A, B, C])
     for idx in range(10):
         fg3.add_factor_by_type(
-            variable_names=[A[idx], B[idx], C[idx]],
+            variables=[A[idx], B[idx], C[idx]],
             factor_type=logical_factor.ANDFactor,
         )
     assert len(fg3.factor_groups[logical_factor.ANDFactor]) == 10

--- a/tests/fg/test_wiring.py
+++ b/tests/fg/test_wiring.py
@@ -25,7 +25,7 @@ def test_wiring_with_PairwiseFactorGroup():
     )
     fg.add_factor_group(factor_group)
 
-    factor_group = fg.factor_groups[enumeration_factor.EnumerationFactor][0]
+    factor_group = fg.factor_groups[0]
     object.__setattr__(
         factor_group, "factor_configs", factor_group.factor_configs[:, :1]
     )
@@ -41,7 +41,7 @@ def test_wiring_with_PairwiseFactorGroup():
         variables_for_factors=[[A[idx], B[idx]] for idx in range(10)]
     )
     fg1.add_factor_group(factor_group)
-    assert len(fg1.factor_groups[enumeration_factor.EnumerationFactor]) == 1
+    assert len(fg1.factor_groups) == 1
 
     # FactorGraph with multiple PairwiseFactorGroup
     fg2 = graph.FactorGraph(variables=[A, B])
@@ -50,7 +50,7 @@ def test_wiring_with_PairwiseFactorGroup():
             variables_for_factors=[[A[idx], B[idx]]]
         )
         fg2.add_factor_group(factor_group)
-    assert len(fg2.factor_groups[enumeration_factor.EnumerationFactor]) == 10
+    assert len(fg2.factor_groups) == 10
 
     # FactorGraph with multiple SingleFactorGroup
     fg3 = graph.FactorGraph(variables=[A, B])
@@ -61,7 +61,7 @@ def test_wiring_with_PairwiseFactorGroup():
             log_potentials=np.zeros((4,)),
         )
         fg3.add_factor(factor)
-    assert len(fg3.factor_groups[enumeration_factor.EnumerationFactor]) == 10
+    assert len(fg3.factor_groups) == 10
 
     assert len(fg1.factors) == len(fg2.factors) == len(fg3.factors)
 
@@ -100,7 +100,7 @@ def test_wiring_with_ORFactorGroup():
         variables_for_factors=[[A[idx], B[idx], C[idx]] for idx in range(10)],
     )
     fg1.add_factor_group(factor_group)
-    assert len(fg1.factor_groups[logical_factor.ORFactor]) == 1
+    assert len(fg1.factor_groups) == 1
 
     # FactorGraph with multiple ORFactorGroup
     fg2 = graph.FactorGraph(variables=[A, B, C])
@@ -109,7 +109,7 @@ def test_wiring_with_ORFactorGroup():
             variables_for_factors=[[A[idx], B[idx], C[idx]]],
         )
         fg2.add_factor_group(factor_group)
-    assert len(fg2.factor_groups[logical_factor.ORFactor]) == 10
+    assert len(fg2.factor_groups) == 10
 
     # FactorGraph with multiple SingleFactorGroup
     fg3 = graph.FactorGraph(variables=[A, B, C])
@@ -118,7 +118,7 @@ def test_wiring_with_ORFactorGroup():
             variables=[A[idx], B[idx], C[idx]],
         )
         fg3.add_factor(factor)
-    assert len(fg3.factor_groups[logical_factor.ORFactor]) == 10
+    assert len(fg3.factor_groups) == 10
 
     assert len(fg1.factors) == len(fg2.factors) == len(fg3.factors)
 
@@ -155,7 +155,7 @@ def test_wiring_with_ANDFactorGroup():
         variables_for_factors=[[A[idx], B[idx], C[idx]] for idx in range(10)],
     )
     fg1.add_factor_group(factor_group)
-    assert len(fg1.factor_groups[logical_factor.ANDFactor]) == 1
+    assert len(fg1.factor_groups) == 1
 
     # FactorGraph with multiple ANDFactorGroup
     fg2 = graph.FactorGraph(variables=[A, B, C])
@@ -164,7 +164,7 @@ def test_wiring_with_ANDFactorGroup():
             variables_for_factors=[[A[idx], B[idx], C[idx]]],
         )
         fg2.add_factor_group(factor_group)
-    assert len(fg2.factor_groups[logical_factor.ANDFactor]) == 10
+    assert len(fg2.factor_groups) == 10
 
     # FactorGraph with multiple SingleFactorGroup
     fg3 = graph.FactorGraph(variables=[A, B, C])
@@ -173,7 +173,7 @@ def test_wiring_with_ANDFactorGroup():
             variables=[A[idx], B[idx], C[idx]],
         )
         fg3.add_factor(factor)
-    assert len(fg3.factor_groups[logical_factor.ANDFactor]) == 10
+    assert len(fg3.factor_groups) == 10
 
     assert len(fg1.factors) == len(fg2.factors) == len(fg3.factors)
 

--- a/tests/fg/test_wiring.py
+++ b/tests/fg/test_wiring.py
@@ -19,10 +19,10 @@ def test_wiring_with_PairwiseFactorGroup():
     B = vgroup.NDVariableArray(num_states=2, shape=(10,))
 
     # First test that compile_wiring enforces the correct factor_edges_num_states shape
-    fg = graph.FactorGraph(variables=dict(A=A, B=B))
+    fg = graph.FactorGraph(variables=[A, B])
     fg.add_factor_group(
         factory=enumeration.PairwiseFactorGroup,
-        variable_names_for_factors=[[("A", idx), ("B", idx)] for idx in range(10)],
+        variable_names_for_factors=[[A[idx], B[idx]] for idx in range(10)],
     )
     factor_group = fg.factor_groups[enumeration_factor.EnumerationFactor][0]
     object.__setattr__(
@@ -37,27 +37,27 @@ def test_wiring_with_PairwiseFactorGroup():
         factor_group.compile_wiring(fg._vars_to_starts)
 
     # FactorGraph with a single PairwiseFactorGroup
-    fg1 = graph.FactorGraph(variables=dict(A=A, B=B))
+    fg1 = graph.FactorGraph(variables=[A, B])
     fg1.add_factor_group(
         factory=enumeration.PairwiseFactorGroup,
-        variable_names_for_factors=[[("A", idx), ("B", idx)] for idx in range(10)],
+        variable_names_for_factors=[[A[idx], B[idx]] for idx in range(10)],
     )
     assert len(fg1.factor_groups[enumeration_factor.EnumerationFactor]) == 1
 
     # FactorGraph with multiple PairwiseFactorGroup
-    fg2 = graph.FactorGraph(variables=dict(A=A, B=B))
+    fg2 = graph.FactorGraph(variables=[A, B])
     for idx in range(10):
         fg2.add_factor_group(
             factory=enumeration.PairwiseFactorGroup,
-            variable_names_for_factors=[[("A", idx), ("B", idx)]],
+            variable_names_for_factors=[[A[idx], B[idx]]],
         )
     assert len(fg2.factor_groups[enumeration_factor.EnumerationFactor]) == 10
 
     # FactorGraph with multiple SingleFactorGroup
-    fg3 = graph.FactorGraph(variables=dict(A=A, B=B))
+    fg3 = graph.FactorGraph(variables=[A, B])
     for idx in range(10):
         fg3.add_factor_by_type(
-            variable_names=[("A", idx), ("B", idx)],
+            variable_names=[A[idx], B[idx]],
             factor_type=enumeration_factor.EnumerationFactor,
             **{
                 "factor_configs": np.array([[0, 0], [0, 1], [1, 0], [1, 1]]),
@@ -98,29 +98,27 @@ def test_wiring_with_ORFactorGroup():
     C = vgroup.NDVariableArray(num_states=2, shape=(10,))
 
     # FactorGraph with a single ORFactorGroup
-    fg1 = graph.FactorGraph(variables=dict(A=A, B=B, C=C))
+    fg1 = graph.FactorGraph(variables=[A, B, C])
     fg1.add_factor_group(
         factory=logical.ORFactorGroup,
-        variable_names_for_factors=[
-            [("A", idx), ("B", idx), ("C", idx)] for idx in range(10)
-        ],
+        variable_names_for_factors=[[A[idx], B[idx], C[idx]] for idx in range(10)],
     )
     assert len(fg1.factor_groups[logical_factor.ORFactor]) == 1
 
     # FactorGraph with multiple ORFactorGroup
-    fg2 = graph.FactorGraph(variables=dict(A=A, B=B, C=C))
+    fg2 = graph.FactorGraph(variables=[A, B, C])
     for idx in range(10):
         fg2.add_factor_group(
             factory=logical.ORFactorGroup,
-            variable_names_for_factors=[[("A", idx), ("B", idx), ("C", idx)]],
+            variable_names_for_factors=[[A[idx], B[idx], C[idx]]],
         )
     assert len(fg2.factor_groups[logical_factor.ORFactor]) == 10
 
     # FactorGraph with multiple SingleFactorGroup
-    fg3 = graph.FactorGraph(variables=dict(A=A, B=B, C=C))
+    fg3 = graph.FactorGraph(variables=[A, B, C])
     for idx in range(10):
         fg3.add_factor_by_type(
-            variable_names=[("A", idx), ("B", idx), ("C", idx)],
+            variable_names=[A[idx], B[idx], C[idx]],
             factor_type=logical_factor.ORFactor,
         )
     assert len(fg3.factor_groups[logical_factor.ORFactor]) == 10
@@ -155,29 +153,27 @@ def test_wiring_with_ANDFactorGroup():
     C = vgroup.NDVariableArray(num_states=2, shape=(10,))
 
     # FactorGraph with a single ANDFactorGroup
-    fg1 = graph.FactorGraph(variables=dict(A=A, B=B, C=C))
+    fg1 = graph.FactorGraph(variables=[A, B, C])
     fg1.add_factor_group(
         factory=logical.ANDFactorGroup,
-        variable_names_for_factors=[
-            [("A", idx), ("B", idx), ("C", idx)] for idx in range(10)
-        ],
+        variable_names_for_factors=[[A[idx], B[idx], C[idx]] for idx in range(10)],
     )
     assert len(fg1.factor_groups[logical_factor.ANDFactor]) == 1
 
     # FactorGraph with multiple ANDFactorGroup
-    fg2 = graph.FactorGraph(variables=dict(A=A, B=B, C=C))
+    fg2 = graph.FactorGraph(variables=[A, B, C])
     for idx in range(10):
         fg2.add_factor_group(
             factory=logical.ANDFactorGroup,
-            variable_names_for_factors=[[("A", idx), ("B", idx), ("C", idx)]],
+            variable_names_for_factors=[[A[idx], B[idx], C[idx]]],
         )
     assert len(fg2.factor_groups[logical_factor.ANDFactor]) == 10
 
     # FactorGraph with multiple SingleFactorGroup
-    fg3 = graph.FactorGraph(variables=dict(A=A, B=B, C=C))
+    fg3 = graph.FactorGraph(variables=[A, B, C])
     for idx in range(10):
         fg3.add_factor_by_type(
-            variable_names=[("A", idx), ("B", idx), ("C", idx)],
+            variable_names=[A[idx], B[idx], C[idx]],
             factor_type=logical_factor.ANDFactor,
         )
     assert len(fg3.factor_groups[logical_factor.ANDFactor]) == 10

--- a/tests/fg/test_wiring.py
+++ b/tests/fg/test_wiring.py
@@ -19,11 +19,11 @@ def test_wiring_with_PairwiseFactorGroup():
     B = vgroup.NDVariableArray(num_states=2, shape=(10,))
 
     # First test that compile_wiring enforces the correct factor_edges_num_states shape
-    fg = graph.FactorGraph(variables=[A, B])
+    fg = graph.FactorGraph(variable_groups=[A, B])
     factor_group = enumeration.PairwiseFactorGroup(
         variables_for_factors=[[A[idx], B[idx]] for idx in range(10)]
     )
-    fg.add_factor_group(factor_group)
+    fg.add_factors(factor_group)
 
     factor_group = fg.factor_groups[0]
     object.__setattr__(
@@ -36,31 +36,31 @@ def test_wiring_with_PairwiseFactorGroup():
         factor_group.compile_wiring(fg._vars_to_starts)
 
     # FactorGraph with a single PairwiseFactorGroup
-    fg1 = graph.FactorGraph(variables=[A, B])
+    fg1 = graph.FactorGraph(variable_groups=[A, B])
     factor_group = enumeration.PairwiseFactorGroup(
         variables_for_factors=[[A[idx], B[idx]] for idx in range(10)]
     )
-    fg1.add_factor_group(factor_group)
+    fg1.add_factors(factor_group)
     assert len(fg1.factor_groups) == 1
 
     # FactorGraph with multiple PairwiseFactorGroup
-    fg2 = graph.FactorGraph(variables=[A, B])
+    fg2 = graph.FactorGraph(variable_groups=[A, B])
     for idx in range(10):
         factor_group = enumeration.PairwiseFactorGroup(
             variables_for_factors=[[A[idx], B[idx]]]
         )
-        fg2.add_factor_group(factor_group)
+        fg2.add_factors(factor_group)
     assert len(fg2.factor_groups) == 10
 
     # FactorGraph with multiple SingleFactorGroup
-    fg3 = graph.FactorGraph(variables=[A, B])
+    fg3 = graph.FactorGraph(variable_groups=[A, B])
     for idx in range(10):
         factor = enumeration_factor.EnumerationFactor(
             variables=[A[idx], B[idx]],
             factor_configs=np.array([[0, 0], [0, 1], [1, 0], [1, 1]]),
             log_potentials=np.zeros((4,)),
         )
-        fg3.add_factor(factor)
+        fg3.add_factors(factor=factor)
     assert len(fg3.factor_groups) == 10
 
     assert len(fg1.factors) == len(fg2.factors) == len(fg3.factors)
@@ -95,29 +95,29 @@ def test_wiring_with_ORFactorGroup():
     C = vgroup.NDVariableArray(num_states=2, shape=(10,))
 
     # FactorGraph with a single ORFactorGroup
-    fg1 = graph.FactorGraph(variables=[A, B, C])
+    fg1 = graph.FactorGraph(variable_groups=[A, B, C])
     factor_group = logical.ORFactorGroup(
         variables_for_factors=[[A[idx], B[idx], C[idx]] for idx in range(10)],
     )
-    fg1.add_factor_group(factor_group)
+    fg1.add_factors(factor_group)
     assert len(fg1.factor_groups) == 1
 
     # FactorGraph with multiple ORFactorGroup
-    fg2 = graph.FactorGraph(variables=[A, B, C])
+    fg2 = graph.FactorGraph(variable_groups=[A, B, C])
     for idx in range(10):
         factor_group = logical.ORFactorGroup(
             variables_for_factors=[[A[idx], B[idx], C[idx]]],
         )
-        fg2.add_factor_group(factor_group)
+        fg2.add_factors(factor_group)
     assert len(fg2.factor_groups) == 10
 
     # FactorGraph with multiple SingleFactorGroup
-    fg3 = graph.FactorGraph(variables=[A, B, C])
+    fg3 = graph.FactorGraph(variable_groups=[A, B, C])
     for idx in range(10):
         factor = logical_factor.ORFactor(
             variables=[A[idx], B[idx], C[idx]],
         )
-        fg3.add_factor(factor)
+        fg3.add_factors(factor=factor)
     assert len(fg3.factor_groups) == 10
 
     assert len(fg1.factors) == len(fg2.factors) == len(fg3.factors)
@@ -150,29 +150,29 @@ def test_wiring_with_ANDFactorGroup():
     C = vgroup.NDVariableArray(num_states=2, shape=(10,))
 
     # FactorGraph with a single ANDFactorGroup
-    fg1 = graph.FactorGraph(variables=[A, B, C])
+    fg1 = graph.FactorGraph(variable_groups=[A, B, C])
     factor_group = logical.ANDFactorGroup(
         variables_for_factors=[[A[idx], B[idx], C[idx]] for idx in range(10)],
     )
-    fg1.add_factor_group(factor_group)
+    fg1.add_factors(factor_group)
     assert len(fg1.factor_groups) == 1
 
     # FactorGraph with multiple ANDFactorGroup
-    fg2 = graph.FactorGraph(variables=[A, B, C])
+    fg2 = graph.FactorGraph(variable_groups=[A, B, C])
     for idx in range(10):
         factor_group = logical.ANDFactorGroup(
             variables_for_factors=[[A[idx], B[idx], C[idx]]],
         )
-        fg2.add_factor_group(factor_group)
+        fg2.add_factors(factor_group)
     assert len(fg2.factor_groups) == 10
 
     # FactorGraph with multiple SingleFactorGroup
-    fg3 = graph.FactorGraph(variables=[A, B, C])
+    fg3 = graph.FactorGraph(variable_groups=[A, B, C])
     for idx in range(10):
         factor = logical_factor.ANDFactor(
             variables=[A[idx], B[idx], C[idx]],
         )
-        fg3.add_factor(factor)
+        fg3.add_factors(factor=factor)
     assert len(fg3.factor_groups) == 10
 
     assert len(fg1.factors) == len(fg2.factors) == len(fg3.factors)

--- a/tests/test_pgmax.py
+++ b/tests/test_pgmax.py
@@ -258,7 +258,7 @@ def test_e2e_sanity_check():
                         pass
 
     # Create the factor graph
-    fg = graph.FactorGraph(variables=[grid_vars, additional_vars])
+    fg = graph.FactorGraph(variable_groups=[grid_vars, additional_vars])
 
     # Imperatively add EnumerationFactorGroups (each consisting of just one EnumerationFactor) to
     # the graph!
@@ -302,7 +302,7 @@ def test_e2e_sanity_check():
                         valid_configs_non_supp.shape[0], dtype=float
                     ),
                 )
-                fg.add_factor(factor)
+                fg.add_factors(factor=factor)
             else:
                 factor = EnumerationFactor(
                     variables=curr_vars,
@@ -311,7 +311,7 @@ def test_e2e_sanity_check():
                         valid_configs_non_supp.shape[0], dtype=float
                     ),
                 )
-                fg.add_factor(factor)
+                fg.add_factors(factor=factor)
 
     # Create an EnumerationFactorGroup for vertical suppression factors
     vert_suppression_vars: List[List[Tuple[Any, ...]]] = []
@@ -355,14 +355,14 @@ def test_e2e_sanity_check():
         variables_for_factors=vert_suppression_vars,
         factor_configs=valid_configs_supp,
     )
-    fg.add_factor_group(factor_group)
+    fg.add_factors(factor_group)
 
     factor_group = enumeration.EnumerationFactorGroup(
         variables_for_factors=horz_suppression_vars,
         factor_configs=valid_configs_supp,
         log_potentials=np.zeros(valid_configs_supp.shape[0], dtype=float),
     )
-    fg.add_factor_group(factor_group)
+    fg.add_factors(factor_group)
 
     # Run BP
     # Set the evidence
@@ -419,7 +419,7 @@ def test_e2e_heretic():
                 variables_for_factors=binary_connected_variables(28, 28, k_row, k_col),
                 log_potential_matrix=W_pot[:, :, k_row, k_col],
             )
-            fg.add_factor_group(factor_group)
+            fg.add_factors(factor_group)
 
     # Assign evidence to pixel vars
     bp_state = fg.bp_state

--- a/tests/test_pgmax.py
+++ b/tests/test_pgmax.py
@@ -218,10 +218,10 @@ def test_e2e_sanity_check():
         (grid_vars, (1, 0, 1)): 0,
         (grid_vars, (1, 1, 0)): 1,
         (grid_vars, (1, 1, 1)): 0,
-        (additional_vars, ((0, 0, 2), 3)): 0,
-        (additional_vars, ((0, 1, 2), 3)): 2,
-        (additional_vars, ((1, 2, 0), 3)): 1,
-        (additional_vars, ((1, 2, 1), 3)): 0,
+        (additional_vars, ((additional_vars.__hash__(), (0, 0, 2)), 3)): 0,
+        (additional_vars, ((additional_vars.__hash__(), (0, 1, 2)), 3)): 2,
+        (additional_vars, ((additional_vars.__hash__(), (1, 2, 0)), 3)): 1,
+        (additional_vars, ((additional_vars.__hash__(), (1, 2, 1)), 3)): 0,
     }
 
     gt_has_cuts = gt_has_cuts.astype(np.int32)

--- a/tests/test_pgmax.py
+++ b/tests/test_pgmax.py
@@ -265,14 +265,14 @@ def test_e2e_sanity_check():
     for row in range(M - 1):
         for col in range(N - 1):
             if row != M - 2 and col != N - 2:
-                curr_names = [
+                curr_vars = [
                     grid_vars[0, row, col],
                     grid_vars[1, row, col],
                     grid_vars[0, row, col + 1],
                     grid_vars[1, row + 1, col],
                 ]
             elif row != M - 2:
-                curr_names = [
+                curr_vars = [
                     grid_vars[0, row, col],
                     grid_vars[1, row, col],
                     additional_vars[0, row, col + 1],
@@ -280,7 +280,7 @@ def test_e2e_sanity_check():
                 ]
 
             elif col != N - 2:
-                curr_names = [
+                curr_vars = [
                     grid_vars[0, row, col],
                     grid_vars[1, row, col],
                     grid_vars[0, row, col + 1],
@@ -288,7 +288,7 @@ def test_e2e_sanity_check():
                 ]
 
             else:
-                curr_names = [
+                curr_vars = [
                     grid_vars[0, row, col],
                     grid_vars[1, row, col],
                     additional_vars[0, row, col + 1],
@@ -296,54 +296,54 @@ def test_e2e_sanity_check():
                 ]
             if row % 2 == 0:
                 factor = EnumerationFactor(
-                    variables=curr_names,
+                    variables=curr_vars,
                     factor_configs=valid_configs_non_supp,
                     log_potentials=np.zeros(
                         valid_configs_non_supp.shape[0], dtype=float
                     ),
                 )
-                fg.add_factor(factor, name=(row, col))
+                fg.add_factor(factor)
             else:
                 factor = EnumerationFactor(
-                    variables=curr_names,
+                    variables=curr_vars,
                     factor_configs=valid_configs_non_supp,
                     log_potentials=np.zeros(
                         valid_configs_non_supp.shape[0], dtype=float
                     ),
                 )
-                fg.add_factor(factor, name=(row, col))
+                fg.add_factor(factor)
 
     # Create an EnumerationFactorGroup for vertical suppression factors
-    vert_suppression_names: List[List[Tuple[Any, ...]]] = []
+    vert_suppression_vars: List[List[Tuple[Any, ...]]] = []
     for col in range(N):
         for start_row in range(M - SUPPRESSION_DIAMETER):
             if col != N - 1:
-                vert_suppression_names.append(
+                vert_suppression_vars.append(
                     [
                         grid_vars[0, r, col]
                         for r in range(start_row, start_row + SUPPRESSION_DIAMETER)
                     ]
                 )
             else:
-                vert_suppression_names.append(
+                vert_suppression_vars.append(
                     [
                         additional_vars[0, r, col]
                         for r in range(start_row, start_row + SUPPRESSION_DIAMETER)
                     ]
                 )
 
-    horz_suppression_names: List[List[Tuple[Any, ...]]] = []
+    horz_suppression_vars: List[List[Tuple[Any, ...]]] = []
     for row in range(M):
         for start_col in range(N - SUPPRESSION_DIAMETER):
             if row != M - 1:
-                horz_suppression_names.append(
+                horz_suppression_vars.append(
                     [
                         grid_vars[1, row, c]
                         for c in range(start_col, start_col + SUPPRESSION_DIAMETER)
                     ]
                 )
             else:
-                horz_suppression_names.append(
+                horz_suppression_vars.append(
                     [
                         additional_vars[1, row, c]
                         for c in range(start_col, start_col + SUPPRESSION_DIAMETER)
@@ -352,13 +352,13 @@ def test_e2e_sanity_check():
 
     # Add the suppression factors to the graph via kwargs
     factor_group = enumeration.EnumerationFactorGroup(
-        variables_for_factors=vert_suppression_names,
+        variables_for_factors=vert_suppression_vars,
         factor_configs=valid_configs_supp,
     )
     fg.add_factor_group(factor_group)
 
     factor_group = enumeration.EnumerationFactorGroup(
-        variables_for_factors=horz_suppression_names,
+        variables_for_factors=horz_suppression_vars,
         factor_configs=valid_configs_supp,
         log_potentials=np.zeros(valid_configs_supp.shape[0], dtype=float),
     )
@@ -419,7 +419,7 @@ def test_e2e_heretic():
                 variables_for_factors=binary_connected_variables(28, 28, k_row, k_col),
                 log_potential_matrix=W_pot[:, :, k_row, k_col],
             )
-            fg.add_factor_group(factor_group, name=(k_row, k_col))
+            fg.add_factor_group(factor_group)
 
     # Assign evidence to pixel vars
     bp_state = fg.bp_state

--- a/tests/test_pgmax.py
+++ b/tests/test_pgmax.py
@@ -207,7 +207,7 @@ def test_e2e_sanity_check():
     extra_row_names: List[Tuple[Any, ...]] = [(0, row, N - 1) for row in range(M - 1)]
     extra_col_names: List[Tuple[Any, ...]] = [(1, M - 1, col) for col in range(N - 1)]
     additional_names = tuple(extra_row_names + extra_col_names)
-    additional_vars = vgroup.VariableDict(additional_names, num_states=3)
+    additional_vars = vgroup.VariableDict(variable_names=additional_names, num_states=3)
 
     true_map_state_output = {
         (grid_vars, (0, 0, 0)): 2,
@@ -218,10 +218,14 @@ def test_e2e_sanity_check():
         (grid_vars, (1, 0, 1)): 0,
         (grid_vars, (1, 1, 0)): 1,
         (grid_vars, (1, 1, 1)): 0,
-        (additional_vars, ((additional_vars.__hash__(), (0, 0, 2)), 3)): 0,
-        (additional_vars, ((additional_vars.__hash__(), (0, 1, 2)), 3)): 2,
-        (additional_vars, ((additional_vars.__hash__(), (1, 2, 0)), 3)): 1,
-        (additional_vars, ((additional_vars.__hash__(), (1, 2, 1)), 3)): 0,
+        # (additional_vars, ((additional_vars.__hash__(), (0, 0, 2)), 3)): 0,
+        # (additional_vars, ((additional_vars.__hash__(), (0, 1, 2)), 3)): 2,
+        # (additional_vars, ((additional_vars.__hash__(), (1, 2, 0)), 3)): 1,
+        # (additional_vars, ((additional_vars.__hash__(), (1, 2, 1)), 3)): 0,
+        (additional_vars, (0, 0, 2)): 0,
+        (additional_vars, (0, 1, 2)): 2,
+        (additional_vars, (1, 2, 0)): 1,
+        (additional_vars, (1, 2, 1)): 0,
     }
 
     gt_has_cuts = gt_has_cuts.astype(np.int32)
@@ -251,9 +255,7 @@ def test_e2e_sanity_check():
                 except IndexError:
                     try:
                         _ = additional_vars[i, row, col]
-                        additional_vars_evidence_dict[
-                            additional_vars[i, row, col]
-                        ] = evidence_vals_arr
+                        additional_vars_evidence_dict[i, row, col] = evidence_vals_arr
                     except ValueError:
                         pass
 
@@ -302,7 +304,7 @@ def test_e2e_sanity_check():
                         valid_configs_non_supp.shape[0], dtype=float
                     ),
                 )
-                fg.add_factors(factor=factor)
+                fg.add_factors(factor)
             else:
                 factor = EnumerationFactor(
                     variables=curr_vars,
@@ -311,7 +313,7 @@ def test_e2e_sanity_check():
                         valid_configs_non_supp.shape[0], dtype=float
                     ),
                 )
-                fg.add_factors(factor=factor)
+                fg.add_factors(factor)
 
     # Create an EnumerationFactorGroup for vertical suppression factors
     vert_suppression_vars: List[List[Tuple[Any, ...]]] = []

--- a/tests/test_pgmax.py
+++ b/tests/test_pgmax.py
@@ -217,10 +217,10 @@ def test_e2e_sanity_check():
         (grid_vars, (1, 0, 1)): 0,
         (grid_vars, (1, 1, 0)): 1,
         (grid_vars, (1, 1, 1)): 0,
-        (additional_vars, (0, 0, 2)): 0,
-        (additional_vars, (0, 1, 2)): 2,
-        (additional_vars, (1, 2, 0)): 1,
-        (additional_vars, (1, 2, 1)): 0,
+        (additional_vars, ((0, 0, 2), 3)): 0,
+        (additional_vars, ((0, 1, 2), 3)): 2,
+        (additional_vars, ((1, 2, 0), 3)): 1,
+        (additional_vars, ((1, 2, 1), 3)): 0,
     }
 
     gt_has_cuts = gt_has_cuts.astype(np.int32)

--- a/tests/test_pgmax.py
+++ b/tests/test_pgmax.py
@@ -6,7 +6,7 @@ import numpy as np
 from numpy.random import default_rng
 from scipy.ndimage import gaussian_filter
 
-from pgmax.fg import graph, groups, nodes
+from pgmax.fg import graph, nodes
 from pgmax.groups import enumeration
 from pgmax.groups import variables as vgroup
 
@@ -121,20 +121,6 @@ def test_e2e_sanity_check():
             ]
         )
     )
-    true_map_state_output = {
-        ("grid_vars", 0, 0, 0): 2,
-        ("grid_vars", 0, 0, 1): 0,
-        ("grid_vars", 0, 1, 0): 0,
-        ("grid_vars", 0, 1, 1): 2,
-        ("grid_vars", 1, 0, 0): 1,
-        ("grid_vars", 1, 0, 1): 0,
-        ("grid_vars", 1, 1, 0): 1,
-        ("grid_vars", 1, 1, 1): 0,
-        ("additional_vars", 0, 0, 2): 0,
-        ("additional_vars", 0, 1, 2): 2,
-        ("additional_vars", 1, 2, 0): 1,
-        ("additional_vars", 1, 2, 1): 0,
-    }
 
     # Create a synthetic depth image for testing purposes
     im_size = 3
@@ -222,6 +208,21 @@ def test_e2e_sanity_check():
     additional_names = tuple(extra_row_names + extra_col_names)
     additional_vars = vgroup.VariableDict(additional_names, num_states=3)
 
+    true_map_state_output = {
+        (grid_vars, (0, 0, 0)): 2,
+        (grid_vars, (0, 0, 1)): 0,
+        (grid_vars, (0, 1, 0)): 0,
+        (grid_vars, (0, 1, 1)): 2,
+        (grid_vars, (1, 0, 0)): 1,
+        (grid_vars, (1, 0, 1)): 0,
+        (grid_vars, (1, 1, 0)): 1,
+        (grid_vars, (1, 1, 1)): 0,
+        (additional_vars, (0, 0, 2)): 0,
+        (additional_vars, (0, 1, 2)): 2,
+        (additional_vars, (1, 2, 0)): 1,
+        (additional_vars, (1, 2, 1)): 0,
+    }
+
     gt_has_cuts = gt_has_cuts.astype(np.int32)
 
     # Now, we use this array along with the gt_has_cuts array computed earlier using the image in order to derive the evidence values
@@ -252,7 +253,7 @@ def test_e2e_sanity_check():
                         additional_vars_evidence_dict[
                             additional_vars[i, row, col]
                         ] = evidence_vals_arr
-                    except IndexError:
+                    except ValueError:
                         pass
 
     # Create the factor graph
@@ -378,7 +379,7 @@ def test_e2e_sanity_check():
     assert jnp.allclose(bp_arrays.ftov_msgs, true_final_msgs_output, atol=1e-06)
     decoded_map_states = graph.decode_map_states(bp.get_beliefs(bp_arrays))
     for name in true_map_state_output:
-        assert true_map_state_output[name] == decoded_map_states[name[0]][name[1:]]
+        assert true_map_state_output[name] == decoded_map_states[name[0]][name[1]]
 
 
 def test_e2e_heretic():

--- a/tests/test_pgmax.py
+++ b/tests/test_pgmax.py
@@ -214,18 +214,13 @@ def test_e2e_sanity_check():
     # We create a NDVariableArray such that the [0,i,j] entry corresponds to the vertical cut variable (i.e, the one
     # attached horizontally to the factor) that's at that location in the image, and the [1,i,j] entry corresponds to
     # the horizontal cut variable (i.e, the one attached vertically to the factor) that's at that location
-    grid_vars_group = vgroup.NDVariableArray(3, (2, M - 1, N - 1))
+    grid_vars = vgroup.NDVariableArray(shape=(2, M - 1, N - 1), num_states=3)
 
     # Make a group of additional variables for the edges of the grid
     extra_row_names: List[Tuple[Any, ...]] = [(0, row, N - 1) for row in range(M - 1)]
     extra_col_names: List[Tuple[Any, ...]] = [(1, M - 1, col) for col in range(N - 1)]
     additional_names = tuple(extra_row_names + extra_col_names)
-    additional_names_group = vgroup.VariableDict(3, additional_names)
-
-    # Combine these two VariableGroups into one CompositeVariableGroup
-    composite_grid_group = groups.CompositeVariableGroup(
-        {"grid_vars": grid_vars_group, "additional_vars": additional_names_group}
-    )
+    additional_vars = vgroup.VariableDict(additional_names, num_states=3)
 
     gt_has_cuts = gt_has_cuts.astype(np.int32)
 
@@ -249,17 +244,19 @@ def test_e2e_sanity_check():
                     size=evidence_vals_arr[1:].shape
                 )  # This adds logistic noise for every evidence entry
                 try:
-                    _ = composite_grid_group["grid_vars", i, row, col]
+                    _ = grid_vars[i, row, col]
                     grid_evidence_arr[i, row, col] = evidence_vals_arr
-                except ValueError:
+                except IndexError:
                     try:
-                        _ = composite_grid_group["additional_vars", i, row, col]
-                        additional_vars_evidence_dict[(i, row, col)] = evidence_vals_arr
-                    except ValueError:
+                        _ = additional_vars[i, row, col]
+                        additional_vars_evidence_dict[
+                            additional_vars[i, row, col]
+                        ] = evidence_vals_arr
+                    except IndexError:
                         pass
 
     # Create the factor graph
-    fg = graph.FactorGraph(variables=composite_grid_group)
+    fg = graph.FactorGraph(variables=[grid_vars, additional_vars])
 
     # Imperatively add EnumerationFactorGroups (each consisting of just one EnumerationFactor) to
     # the graph!
@@ -267,37 +264,37 @@ def test_e2e_sanity_check():
         for col in range(N - 1):
             if row != M - 2 and col != N - 2:
                 curr_names = [
-                    ("grid_vars", 0, row, col),
-                    ("grid_vars", 1, row, col),
-                    ("grid_vars", 0, row, col + 1),
-                    ("grid_vars", 1, row + 1, col),
+                    grid_vars[0, row, col],
+                    grid_vars[1, row, col],
+                    grid_vars[0, row, col + 1],
+                    grid_vars[1, row + 1, col],
                 ]
             elif row != M - 2:
                 curr_names = [
-                    ("grid_vars", 0, row, col),
-                    ("grid_vars", 1, row, col),
-                    ("additional_vars", 0, row, col + 1),
-                    ("grid_vars", 1, row + 1, col),
+                    grid_vars[0, row, col],
+                    grid_vars[1, row, col],
+                    additional_vars[0, row, col + 1],
+                    grid_vars[1, row + 1, col],
                 ]
 
             elif col != N - 2:
                 curr_names = [
-                    ("grid_vars", 0, row, col),
-                    ("grid_vars", 1, row, col),
-                    ("grid_vars", 0, row, col + 1),
-                    ("additional_vars", 1, row + 1, col),
+                    grid_vars[0, row, col],
+                    grid_vars[1, row, col],
+                    grid_vars[0, row, col + 1],
+                    additional_vars[1, row + 1, col],
                 ]
 
             else:
                 curr_names = [
-                    ("grid_vars", 0, row, col),
-                    ("grid_vars", 1, row, col),
-                    ("additional_vars", 0, row, col + 1),
-                    ("additional_vars", 1, row + 1, col),
+                    grid_vars[0, row, col],
+                    grid_vars[1, row, col],
+                    additional_vars[0, row, col + 1],
+                    additional_vars[1, row + 1, col],
                 ]
             if row % 2 == 0:
                 fg.add_factor(
-                    variable_names=curr_names,
+                    variables=curr_names,
                     factor_configs=valid_configs_non_supp,
                     log_potentials=np.zeros(
                         valid_configs_non_supp.shape[0], dtype=float
@@ -306,7 +303,7 @@ def test_e2e_sanity_check():
                 )
             else:
                 fg.add_factor(
-                    variable_names=curr_names,
+                    variables=curr_names,
                     factor_configs=valid_configs_non_supp,
                     log_potentials=np.zeros(
                         valid_configs_non_supp.shape[0], dtype=float
@@ -321,14 +318,14 @@ def test_e2e_sanity_check():
             if col != N - 1:
                 vert_suppression_names.append(
                     [
-                        ("grid_vars", 0, r, col)
+                        grid_vars[0, r, col]
                         for r in range(start_row, start_row + SUPPRESSION_DIAMETER)
                     ]
                 )
             else:
                 vert_suppression_names.append(
                     [
-                        ("additional_vars", 0, r, col)
+                        additional_vars[0, r, col]
                         for r in range(start_row, start_row + SUPPRESSION_DIAMETER)
                     ]
                 )
@@ -339,14 +336,14 @@ def test_e2e_sanity_check():
             if row != M - 1:
                 horz_suppression_names.append(
                     [
-                        ("grid_vars", 1, row, c)
+                        grid_vars[1, row, c]
                         for c in range(start_col, start_col + SUPPRESSION_DIAMETER)
                     ]
                 )
             else:
                 horz_suppression_names.append(
                     [
-                        ("additional_vars", 1, row, c)
+                        additional_vars[1, row, c]
                         for c in range(start_col, start_col + SUPPRESSION_DIAMETER)
                     ]
                 )
@@ -354,12 +351,12 @@ def test_e2e_sanity_check():
     # Add the suppression factors to the graph via kwargs
     fg.add_factor_group(
         factory=enumeration.EnumerationFactorGroup,
-        variable_names_for_factors=vert_suppression_names,
+        variables_for_factors=vert_suppression_names,
         factor_configs=valid_configs_supp,
     )
     fg.add_factor_group(
         factory=enumeration.EnumerationFactorGroup,
-        variable_names_for_factors=horz_suppression_names,
+        variables_for_factors=horz_suppression_names,
         factor_configs=valid_configs_supp,
         log_potentials=np.zeros(valid_configs_supp.shape[0], dtype=float),
     )
@@ -373,8 +370,8 @@ def test_e2e_sanity_check():
             for this_wiring in fg.fg_state.wiring.values()
         ]
     )
-    bp_state.evidence["grid_vars"] = grid_evidence_arr
-    bp_state.evidence["additional_vars"] = additional_vars_evidence_dict
+    bp_state.evidence[grid_vars] = grid_evidence_arr
+    bp_state.evidence[additional_vars] = additional_vars_evidence_dict
     bp = graph.BP(bp_state)
     bp_arrays = bp.run_bp(bp.init(), num_iters=100)
     # Test that the output messages are close to the true messages
@@ -388,15 +385,15 @@ def test_e2e_heretic():
     # Define some global constants
     im_size = (30, 30)
     # Instantiate all the Variables in the factor graph via VariableGroups
-    pixel_vars = vgroup.NDVariableArray(3, im_size)
+    pixel_vars = vgroup.NDVariableArray(shape=im_size, num_states=3)
     hidden_vars = vgroup.NDVariableArray(
-        17, (im_size[0] - 2, im_size[1] - 2)
+        shape=(im_size[0] - 2, im_size[1] - 2), num_states=17
     )  # Each hidden var is connected to a 3x3 patch of pixel vars
 
     bXn = np.zeros((30, 30, 3))
 
     # Create the factor graph
-    fg = graph.FactorGraph((pixel_vars, hidden_vars))
+    fg = graph.FactorGraph([pixel_vars, hidden_vars])
 
     def binary_connected_variables(
         num_hidden_rows, num_hidden_cols, kernel_row, kernel_col
@@ -406,8 +403,8 @@ def test_e2e_heretic():
             for h_col in range(num_hidden_cols):
                 ret_list.append(
                     [
-                        (1, h_row, h_col),
-                        (0, h_row + kernel_row, h_col + kernel_col),
+                        hidden_vars[h_row, h_col],
+                        pixel_vars[h_row + kernel_row, h_col + kernel_col],
                     ]
                 )
         return ret_list
@@ -417,22 +414,20 @@ def test_e2e_heretic():
         for k_col in range(3):
             fg.add_factor_group(
                 factory=enumeration.PairwiseFactorGroup,
-                variable_names_for_factors=binary_connected_variables(
-                    28, 28, k_row, k_col
-                ),
+                variables_for_factors=binary_connected_variables(28, 28, k_row, k_col),
                 log_potential_matrix=W_pot[:, :, k_row, k_col],
                 name=(k_row, k_col),
             )
 
     # Assign evidence to pixel vars
     bp_state = fg.bp_state
-    bp_state.evidence[0] = np.array(bXn)
-    bp_state.evidence[0, 0, 0] = np.array([0.0, 0.0, 0.0])
-    bp_state.evidence[0, 0, 0]
-    bp_state.evidence[1, 0, 0]
+    bp_state.evidence[pixel_vars] = np.array(bXn)
+    bp_state.evidence[pixel_vars[0, 0]] = np.array([0.0, 0.0, 0.0])
+    bp_state.evidence[pixel_vars[0, 0]]
+    bp_state.evidence[hidden_vars[0, 0]]
     assert isinstance(bp_state.evidence.value, np.ndarray)
     assert len(sum(fg.factors.values(), ())) == 7056
     bp = graph.BP(bp_state, temperature=1.0)
     bp_arrays = bp.run_bp(bp.init(), num_iters=1)
     marginals = graph.get_marginals(bp.get_beliefs(bp_arrays))
-    assert jnp.allclose(jnp.sum(marginals[0], axis=-1), 1.0)
+    assert jnp.allclose(jnp.sum(marginals[pixel_vars], axis=-1), 1.0)


### PR DESCRIPTION
We update the way of representing variables. In particular:
- We get rid of variables names, as welll as of the `Variables` and `CompositeVariableGroup` classes. A variable is now represented by a tuple `(variable hash, variable num_states)`
  In particular, a FactorGraph can then directly be instantiated as`fg = graph.FactorGraph(variables=[hidden_variables, visible_variables])`
  Similarly,  Factors are defined by directly passing the variables involved, as `[hidden_variables[ii], visible_variables[jj]]`
- We rewrite `NDVariableArray` so that the user can access variables by relying on the use of numpy arrays. We also optimize some follow-up computations. 
